### PR TITLE
fix: Disable the overlay for bedwars duels

### DIFF
--- a/src/prism/overlay/parsing.py
+++ b/src/prism/overlay/parsing.py
@@ -310,6 +310,10 @@ def parse_chat_message(message: str) -> ChatEvent | None:
 
     # NOTE: This also appears at the end of a game, but before endgameevent is sent
     if message.strip().startswith("Bed Wars"):
+        if message.strip().startswith("Bed Wars Duels"):
+            logger.debug("Starting bedwars duels game - not starting game")
+            return None
+
         logger.debug("Parsing passed. Starting game")
         return StartBedwarsGameEvent()
 

--- a/tests/prism/overlay/test_parsing.py
+++ b/tests/prism/overlay/test_parsing.py
@@ -384,6 +384,8 @@ UNEVENTFUL_LOGLINES = (
     # Team chat
     "[21:18:20] [Client thread/INFO]: [CHAT] §c§7[5✫] §c[RED] §7Player1§7: def",
     # #########################################
+    # Bedwars duels
+    "[21:23:52] [Client thread/INFO]: [CHAT]                              Bed Wars Duels",
 )
 
 


### PR DESCRIPTION
The new bedwars duels update triggers the overlay, and specifically the
autowho feature. This is okay in the regular bedwars duel, but is
annoying in the bedwars rush duel. Disable it completely for now, with
the potential option of adding a setting for it at a later point.
