### PR TITLE
feat: Add setting for disabling the overlay in bedwars duels

### DIFF
--- a/src/prism/overlay/events.py
+++ b/src/prism/overlay/events.py
@@ -134,6 +134,7 @@ class BedwarsGameStartingSoonEvent:
 
 @dataclass
 class StartBedwarsGameEvent:
+    is_bedwars_duel: bool
     event_type: Literal[EventType.START_BEDWARS_GAME] = EventType.START_BEDWARS_GAME
 
 

--- a/src/prism/overlay/output/overlay/settings_page.py
+++ b/src/prism/overlay/output/overlay/settings_page.py
@@ -239,6 +239,21 @@ class GeneralSettingSection:  # pragma: nocover
                 cursor="hand2" if enabled else "arrow",
             )
 
+        activate_in_bedwars_duels_label = tk.Label(
+            self.frame,
+            text="Activate in Bedwars Duels: ",
+            font=("Consolas", 12),
+            foreground="white",
+            background="black",
+        )
+        activate_in_bedwars_duels_label.grid(row=4, column=0, sticky=tk.E)
+        self.activate_in_bedwars_duels_toggle = ToggleButton(self.frame)
+        self.activate_in_bedwars_duels_toggle.button.grid(row=4, column=1)
+        parent.make_widgets_scrollable(
+            activate_in_bedwars_duels_label,
+            self.activate_in_bedwars_duels_toggle.button,
+        )
+
         check_for_updates_label = tk.Label(
             self.frame,
             text="Check for major version updates: ",
@@ -246,11 +261,11 @@ class GeneralSettingSection:  # pragma: nocover
             foreground="white",
             background="black",
         )
-        check_for_updates_label.grid(row=4, column=0, sticky=tk.E)
+        check_for_updates_label.grid(row=5, column=0, sticky=tk.E)
         self.check_for_updates_toggle = ToggleButton(
             self.frame, toggle_callback=disable_include_patch_updates_toggle
         )
-        self.check_for_updates_toggle.button.grid(row=4, column=1)
+        self.check_for_updates_toggle.button.grid(row=5, column=1)
         parent.make_widgets_scrollable(
             check_for_updates_label,
             self.check_for_updates_toggle.button,
@@ -263,9 +278,9 @@ class GeneralSettingSection:  # pragma: nocover
             foreground="white",
             background="black",
         )
-        include_patch_updates_label.grid(row=5, column=0, sticky=tk.E)
+        include_patch_updates_label.grid(row=6, column=0, sticky=tk.E)
         self.include_patch_updates_toggle = ToggleButton(self.frame)
-        self.include_patch_updates_toggle.button.grid(row=5, column=1)
+        self.include_patch_updates_toggle.button.grid(row=6, column=1)
         parent.make_widgets_scrollable(
             include_patch_updates_label,
             self.include_patch_updates_toggle.button,
@@ -278,9 +293,9 @@ class GeneralSettingSection:  # pragma: nocover
             foreground="white",
             background="black",
         )
-        use_included_certs_label.grid(row=6, column=0, sticky=tk.E)
+        use_included_certs_label.grid(row=7, column=0, sticky=tk.E)
         self.use_included_certs_toggle = ToggleButton(self.frame)
-        self.use_included_certs_toggle.button.grid(row=6, column=1)
+        self.use_included_certs_toggle.button.grid(row=7, column=1)
         parent.make_widgets_scrollable(
             use_included_certs_label,
             self.use_included_certs_toggle.button,
@@ -299,7 +314,7 @@ class GeneralSettingSection:  # pragma: nocover
                 foreground="red",
                 background="black",
             )
-            show_on_tab_disabled_label.grid(row=7, column=0, columnspan=2)
+            show_on_tab_disabled_label.grid(row=8, column=0, columnspan=2)
             parent.make_widgets_scrollable(show_on_tab_disabled_label)
 
     def set(
@@ -308,6 +323,7 @@ class GeneralSettingSection:  # pragma: nocover
         autoselect_logfile: bool,
         show_on_tab: bool,
         show_on_tab_keybind: Key,
+        activate_in_bedwars_duels: bool,
         check_for_updates: bool,
         include_patch_updates: bool,
         use_included_certs: bool,
@@ -317,17 +333,19 @@ class GeneralSettingSection:  # pragma: nocover
         self.autoselect_logfile_toggle.set(autoselect_logfile)
         self.show_on_tab_toggle.set(show_on_tab)
         self.show_on_tab_keybind_selector.set_key(show_on_tab_keybind)
+        self.activate_in_bedwars_duels_toggle.set(activate_in_bedwars_duels)
         self.check_for_updates_toggle.set(check_for_updates)
         self.include_patch_updates_toggle.set(include_patch_updates)
         self.use_included_certs_toggle.set(use_included_certs)
 
-    def get(self) -> tuple[bool, bool, bool, Key, bool, bool, bool]:
+    def get(self) -> tuple[bool, bool, bool, Key, bool, bool, bool, bool]:
         """Get the state of this section"""
         return (
             self.autodenick_teammates_toggle.enabled,
             self.autoselect_logfile_toggle.enabled,
             self.show_on_tab_toggle.enabled,
             self.show_on_tab_keybind_selector.key,
+            self.activate_in_bedwars_duels_toggle.enabled,
             self.check_for_updates_toggle.enabled,
             self.include_patch_updates_toggle.enabled,
             self.use_included_certs_toggle.enabled,
@@ -1282,6 +1300,7 @@ class SettingsPage:  # pragma: nocover
                 autoselect_logfile=settings.autoselect_logfile,
                 show_on_tab=settings.show_on_tab,
                 show_on_tab_keybind=settings.show_on_tab_keybind,
+                activate_in_bedwars_duels=settings.activate_in_bedwars_duels,
                 check_for_updates=settings.check_for_updates,
                 include_patch_updates=settings.include_patch_updates,
                 use_included_certs=settings.use_included_certs,
@@ -1334,6 +1353,7 @@ class SettingsPage:  # pragma: nocover
             autoselect_logfile,
             show_on_tab,
             show_on_tab_keybind,
+            activate_in_bedwars_duels,
             check_for_updates,
             include_patch_updates,
             use_included_certs,
@@ -1380,6 +1400,7 @@ class SettingsPage:  # pragma: nocover
             autowho=autowho,
             autowho_delay=autowho_delay,
             chat_hotkey=chat_hotkey.to_dict(),
+            activate_in_bedwars_duels=activate_in_bedwars_duels,
             check_for_updates=check_for_updates,
             include_patch_updates=include_patch_updates,
             use_included_certs=use_included_certs,

--- a/src/prism/overlay/parsing.py
+++ b/src/prism/overlay/parsing.py
@@ -310,12 +310,10 @@ def parse_chat_message(message: str) -> ChatEvent | None:
 
     # NOTE: This also appears at the end of a game, but before endgameevent is sent
     if message.strip().startswith("Bed Wars"):
-        if message.strip().startswith("Bed Wars Duels"):
-            logger.debug("Starting bedwars duels game - not starting game")
-            return None
+        is_bedwars_duel = message.strip().startswith("Bed Wars Duels")
 
-        logger.debug("Parsing passed. Starting game")
-        return StartBedwarsGameEvent()
+        logger.debug(f"Parsing passed. Starting game {is_bedwars_duel=}")
+        return StartBedwarsGameEvent(is_bedwars_duel=is_bedwars_duel)
 
     if (
         message.strip(PUNCTUATION_AND_WHITESPACE).endswith("FINAL KILL")

--- a/src/prism/overlay/process_event.py
+++ b/src/prism/overlay/process_event.py
@@ -187,7 +187,11 @@ def process_event(
 
     if event.event_type is EventType.START_BEDWARS_GAME:
         # Bedwars game has started
-        logger.info("Bedwars game starting")
+        logger.info(f"Bedwars game starting (duel={event.is_bedwars_duel})")
+
+        if not controller.settings.activate_in_bedwars_duels and event.is_bedwars_duel:
+            logger.info("Not activating overlay in bedwars duels due to setting")
+            return state, False
 
         if controller.ready:
             controller.autowho_event.set()

--- a/src/prism/overlay/settings.py
+++ b/src/prism/overlay/settings.py
@@ -59,6 +59,7 @@ class SettingsDict(TypedDict):
     autowho: bool
     autowho_delay: float
     chat_hotkey: KeyDict
+    activate_in_bedwars_duels: bool
     check_for_updates: bool
     include_patch_updates: bool
     use_included_certs: bool
@@ -93,6 +94,7 @@ class Settings:
     autowho: bool
     autowho_delay: float
     chat_hotkey: Key
+    activate_in_bedwars_duels: bool
     check_for_updates: bool
     include_patch_updates: bool
     use_included_certs: bool
@@ -140,6 +142,7 @@ class Settings:
             autowho=source["autowho"],
             autowho_delay=source["autowho_delay"],
             chat_hotkey=construct_key(source["chat_hotkey"]),
+            activate_in_bedwars_duels=source["activate_in_bedwars_duels"],
             check_for_updates=source["check_for_updates"],
             include_patch_updates=source["include_patch_updates"],
             use_included_certs=source["use_included_certs"],
@@ -173,6 +176,7 @@ class Settings:
             "autowho": self.autowho,
             "autowho_delay": self.autowho_delay,
             "chat_hotkey": self.chat_hotkey.to_dict(),
+            "activate_in_bedwars_duels": self.activate_in_bedwars_duels,
             "check_for_updates": self.check_for_updates,
             "include_patch_updates": self.include_patch_updates,
             "use_included_certs": self.use_included_certs,
@@ -207,6 +211,7 @@ class Settings:
         self.autowho = new_settings["autowho"]
         self.autowho_delay = new_settings["autowho_delay"]
         self.chat_hotkey = construct_key(new_settings["chat_hotkey"])
+        self.activate_in_bedwars_duels = new_settings["activate_in_bedwars_duels"]
         self.check_for_updates = new_settings["check_for_updates"]
         self.include_patch_updates = new_settings["include_patch_updates"]
         self.use_included_certs = new_settings["use_included_certs"]
@@ -395,6 +400,13 @@ def fill_missing_settings(
     else:
         chat_hotkey = chat_hotkey_dict
 
+    activate_in_bedwars_duels, settings_updated = get_boolean_setting(
+        incomplete_settings,
+        "activate_in_bedwars_duels",
+        settings_updated,
+        default=False,
+    )
+
     check_for_updates, settings_updated = get_boolean_setting(
         incomplete_settings, "check_for_updates", settings_updated, default=True
     )
@@ -465,6 +477,7 @@ def fill_missing_settings(
         "autowho": autowho,
         "autowho_delay": autowho_delay,
         "chat_hotkey": chat_hotkey,
+        "activate_in_bedwars_duels": activate_in_bedwars_duels,
         "check_for_updates": check_for_updates,
         "include_patch_updates": include_patch_updates,
         "use_included_certs": use_included_certs,

--- a/tests/prism/overlay/test_behaviour.py
+++ b/tests/prism/overlay/test_behaviour.py
@@ -318,6 +318,7 @@ def test_update_settings_everything_changed() -> None:
         autowho=False,
         autowho_delay=4.5,
         chat_hotkey=AlphanumericKeyDict(name="u", char="u", key_type="alphanumeric"),
+        activate_in_bedwars_duels=True,
         check_for_updates=False,
         include_patch_updates=True,
         use_included_certs=False,

--- a/tests/prism/overlay/test_parsing.py
+++ b/tests/prism/overlay/test_parsing.py
@@ -384,8 +384,6 @@ UNEVENTFUL_LOGLINES = (
     # Team chat
     "[21:18:20] [Client thread/INFO]: [CHAT] §c§7[5✫] §c[RED] §7Player1§7: def",
     # #########################################
-    # Bedwars duels
-    "[21:23:52] [Client thread/INFO]: [CHAT]                              Bed Wars Duels",
 )
 
 
@@ -716,13 +714,17 @@ parsing_test_cases: tuple[tuple[str, Event | None], ...] = (
         BedwarsGameStartingSoonEvent(seconds=1),
     ),
     (
+        "[21:23:52] [Client thread/INFO]: [CHAT]                              Bed Wars Duels",
+        StartBedwarsGameEvent(is_bedwars_duel=True),
+    ),
+    (
         "[16:12:21] [Client thread/INFO]: [CHAT]                                   Bed Wars ",
-        StartBedwarsGameEvent(),
+        StartBedwarsGameEvent(is_bedwars_duel=False),
     ),
     (
         # Start game on astolfo chat bridge
         "[04:05:13] [Astolfo HTTP Bridge]: [CHAT]                                   Bed Wars",
-        StartBedwarsGameEvent(),
+        StartBedwarsGameEvent(is_bedwars_duel=False),
     ),
     (
         "[00:01:04] [Client thread/INFO]: [CHAT] Player1 was spooked off the map by Player2. FINAL KILL!",

--- a/tests/prism/overlay/test_process_event.py
+++ b/tests/prism/overlay/test_process_event.py
@@ -32,7 +32,12 @@ from prism.overlay.process_event import (
     process_event,
     process_loglines,
 )
-from tests.prism.overlay.utils import OWN_USERNAME, MockedController, create_state
+from tests.prism.overlay.utils import (
+    OWN_USERNAME,
+    MockedController,
+    create_state,
+    make_settings,
+)
 
 process_event_test_cases_base: tuple[
     tuple[str, MockedController, Event, MockedController, bool], ...
@@ -281,11 +286,41 @@ process_event_test_cases_base: tuple[
         MockedController(
             wants_shown=False, state=create_state(in_queue=True, now_func=lambda: 1234)
         ),
-        StartBedwarsGameEvent(),
+        StartBedwarsGameEvent(is_bedwars_duel=False),
         MockedController(
             wants_shown=None,
             autowho_event_set=True,
             state=create_state(in_queue=False, out_of_sync=True, last_game_start=1234),
+        ),
+        False,  # No need to redraw the screen - only hide the overlay
+    ),
+    (
+        "start bedwars duels game when disabled in duels",
+        MockedController(
+            wants_shown=False,
+            state=create_state(in_queue=True),
+            # Disabled in duels is the default
+        ),
+        StartBedwarsGameEvent(is_bedwars_duel=True),
+        MockedController(
+            wants_shown=False,
+            state=create_state(in_queue=True),
+        ),
+        False,
+    ),
+    (
+        "start bedwars duels game when enabled in duels",
+        MockedController(
+            wants_shown=False,
+            state=create_state(in_queue=True, now_func=lambda: 1234),
+            settings=make_settings(activate_in_bedwars_duels=True),
+        ),
+        StartBedwarsGameEvent(is_bedwars_duel=True),
+        MockedController(
+            wants_shown=None,
+            autowho_event_set=True,
+            state=create_state(in_queue=False, out_of_sync=True, last_game_start=1234),
+            settings=make_settings(activate_in_bedwars_duels=True),
         ),
         False,  # No need to redraw the screen - only hide the overlay
     ),
@@ -297,7 +332,7 @@ process_event_test_cases_base: tuple[
             wants_shown=False,
             state=create_state(in_queue=True, now_func=lambda: 1234),
         ),
-        StartBedwarsGameEvent(),
+        StartBedwarsGameEvent(is_bedwars_duel=False),
         MockedController(
             ready=False,
             wants_shown=None,

--- a/tests/prism/overlay/test_settings.py
+++ b/tests/prism/overlay/test_settings.py
@@ -62,6 +62,7 @@ def make_settings_dict(
     autowho: bool | None = None,
     autowho_delay: float | None = None,
     chat_hotkey: KeyDict | None = None,
+    activate_in_bedwars_duels: bool | None = None,
     check_for_updates: bool | None = None,
     include_patch_updates: bool | None = None,
     use_included_certs: bool | None = None,
@@ -106,6 +107,9 @@ def make_settings_dict(
             chat_hotkey,
             default=AlphanumericKeyDict(name="t", char="t", key_type="alphanumeric"),
         ),
+        "activate_in_bedwars_duels": value_or_default(
+            activate_in_bedwars_duels, default=False
+        ),
         "check_for_updates": value_or_default(check_for_updates, default=True),
         "include_patch_updates": value_or_default(include_patch_updates, default=False),
         "use_included_certs": value_or_default(use_included_certs, default=True),
@@ -148,6 +152,7 @@ settings_to_dict_cases: tuple[tuple[Settings, SettingsDict], ...] = (
             autowho=True,
             autowho_delay=2.1,
             chat_hotkey=AlphanumericKey(name="u", char="u"),
+            activate_in_bedwars_duels=False,
             check_for_updates=True,
             include_patch_updates=False,
             use_included_certs=False,
@@ -183,6 +188,7 @@ settings_to_dict_cases: tuple[tuple[Settings, SettingsDict], ...] = (
             "chat_hotkey": AlphanumericKeyDict(
                 name="u", char="u", key_type="alphanumeric"
             ),
+            "activate_in_bedwars_duels": False,
             "check_for_updates": True,
             "include_patch_updates": False,
             "use_included_certs": False,
@@ -215,6 +221,7 @@ settings_to_dict_cases: tuple[tuple[Settings, SettingsDict], ...] = (
             autowho=False,
             autowho_delay=0.1,
             chat_hotkey=AlphanumericKey(name="x", char="x"),
+            activate_in_bedwars_duels=True,
             check_for_updates=False,
             include_patch_updates=True,
             use_included_certs=True,
@@ -250,6 +257,7 @@ settings_to_dict_cases: tuple[tuple[Settings, SettingsDict], ...] = (
             "chat_hotkey": AlphanumericKeyDict(
                 name="x", char="x", key_type="alphanumeric"
             ),
+            "activate_in_bedwars_duels": True,
             "check_for_updates": False,
             "include_patch_updates": True,
             "use_included_certs": True,
@@ -426,6 +434,7 @@ fill_settings_test_cases: tuple[
             "chat_hotkey": SpecialKeyDict(
                 name="somekey", vk=1234567, key_type="special"
             ),
+            "activate_in_bedwars_duels": True,
             "check_for_updates": False,
             "include_patch_updates": True,
             "use_included_certs": True,
@@ -457,6 +466,7 @@ fill_settings_test_cases: tuple[
             autowho=True,
             autowho_delay=1,
             chat_hotkey=SpecialKeyDict(name="somekey", vk=1234567, key_type="special"),
+            activate_in_bedwars_duels=True,
             check_for_updates=False,
             include_patch_updates=True,
             use_included_certs=True,

--- a/tests/prism/overlay/utils.py
+++ b/tests/prism/overlay/utils.py
@@ -278,6 +278,7 @@ def make_settings(
     autowho: bool | None = None,
     autowho_delay: float | None = None,
     chat_hotkey: Key | None = None,
+    activate_in_bedwars_duels: bool | None = None,
     path: Path | PurePath | None = None,
 ) -> Settings:
     return Settings.from_dict(
@@ -293,6 +294,7 @@ def make_settings(
                 "chat_hotkey": (
                     chat_hotkey.to_dict() if chat_hotkey is not None else None
                 ),
+                "activate_in_bedwars_duels": activate_in_bedwars_duels,
             },
             2,
         )[0],


### PR DESCRIPTION
Previously just skipped the start game message unconditionally in
bedwars duels, but it could be nice in the regular (non-rush) bedwars
duel. Make it configurable so users can choose :^)
