### PR TITLE
chore: Disable workflow runs on pull request

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -3,7 +3,7 @@ name: Python linting
 permissions:
   contents: read
 
-on: [push, pull_request, workflow_dispatch]
+on: [push, workflow_dispatch]
 
 jobs:
   check-formatting:

--- a/.github/workflows/pip-compile.yml
+++ b/.github/workflows/pip-compile.yml
@@ -3,7 +3,7 @@ name: Python dependencies
 permissions:
   contents: read
 
-on: [push, pull_request, workflow_dispatch]
+on: [push, workflow_dispatch]
 
 jobs:
   test:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,7 +3,7 @@ name: Python testing
 permissions:
   contents: read
 
-on: [push, pull_request, workflow_dispatch]
+on: [push, workflow_dispatch]
 
 jobs:
   test:


### PR DESCRIPTION
We already run the workflows on push, so these are just duplicated on
pull requests.
