### PR TITLE
chore: Add copilot agent setup steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,39 @@
+name: "Copilot Setup Steps"
+
+# Automatically run the setup steps when they are changed to allow for easy validation, and
+# allow manual testing through the repository's "Actions" tab
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: 'pip'
+          cache-dependency-path: requirements/*.txt
+
+      - name: Install dependencies
+        run: |
+          # Install dependencies in the global env, so copilot can access them easily
+          python -m ensurepip
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements/linux.txt -r requirements/linux-dev.txt
+          python -m pip install --no-deps -e .


### PR DESCRIPTION
Copilot was having some issues installing the dependencies, so we do
that for it here.
