### PR TITLE
chore: Unify assert_not_called test helper

### DIFF
--- a/tests/prism/overlay/test_controller.py
+++ b/tests/prism/overlay/test_controller.py
@@ -11,8 +11,7 @@ from prism.ratelimiting import RateLimiter
 from prism.ssl_errors import MissingLocalIssuerSSLError
 from tests.prism.overlay.utils import (
     MockedController,
-    assert_get_estimated_winstreaks_not_called,
-    assert_get_playerdata_not_called,
+    assert_not_called,
     create_state,
     make_settings,
 )
@@ -27,8 +26,8 @@ def test_real_overlay_controller() -> None:
         ),
         nick_database=NickDatabase([{}]),
         get_uuid=lambda username: f"uuid-{username}",
-        get_playerdata=assert_get_playerdata_not_called,
-        get_estimated_winstreaks=assert_get_estimated_winstreaks_not_called,
+        get_playerdata=assert_not_called,
+        get_estimated_winstreaks=assert_not_called,
     )
 
     assert controller.antisniper_key_holder is not None
@@ -44,8 +43,8 @@ def test_real_overlay_controller_no_antisniper_key() -> None:
         ),
         nick_database=NickDatabase([{}]),
         get_uuid=lambda username: f"uuid-{username}",
-        get_playerdata=assert_get_playerdata_not_called,
-        get_estimated_winstreaks=assert_get_estimated_winstreaks_not_called,
+        get_playerdata=assert_not_called,
+        get_estimated_winstreaks=assert_not_called,
     )
 
     assert controller.antisniper_key_holder is None
@@ -71,8 +70,8 @@ def test_real_overlay_controller_get_uuid() -> None:
         ),
         nick_database=NickDatabase([{}]),
         get_uuid=get_uuid_mock,
-        get_playerdata=assert_get_playerdata_not_called,
-        get_estimated_winstreaks=assert_get_estimated_winstreaks_not_called,
+        get_playerdata=assert_not_called,
+        get_estimated_winstreaks=assert_not_called,
     )
 
     error = APIError()
@@ -121,7 +120,7 @@ def test_real_overlay_controller_get_playerdata() -> None:
         nick_database=NickDatabase([{}]),
         get_uuid=lambda username: f"uuid-{username}",
         get_playerdata=mock_get_playerdata,
-        get_estimated_winstreaks=assert_get_estimated_winstreaks_not_called,
+        get_estimated_winstreaks=assert_not_called,
     )
     error = APIError()
     _, playerdata = controller.get_playerdata("uuid")
@@ -176,8 +175,8 @@ def test_real_overlay_controller_get_uuid_dependency_injection() -> None:
         settings=make_settings(),
         nick_database=NickDatabase([{}]),
         get_uuid=custom_get_uuid,
-        get_playerdata=assert_get_playerdata_not_called,
-        get_estimated_winstreaks=assert_get_estimated_winstreaks_not_called,
+        get_playerdata=assert_not_called,
+        get_estimated_winstreaks=assert_not_called,
     )
 
     result = controller.get_uuid("testuser")
@@ -220,7 +219,7 @@ def test_real_overlay_controller_get_playerdata_dependency_injection() -> None:
         nick_database=NickDatabase([{}]),
         get_uuid=lambda username: f"uuid-{username}",
         get_playerdata=custom_get_playerdata,
-        get_estimated_winstreaks=assert_get_estimated_winstreaks_not_called,
+        get_estimated_winstreaks=assert_not_called,
     )
 
     timestamp, result = controller.get_playerdata("test-uuid")
@@ -269,7 +268,7 @@ def test_real_overlay_controller_get_estimated_winstreaks_dependency_injection()
         ),
         nick_database=NickDatabase([{}]),
         get_uuid=lambda username: f"uuid-{username}",
-        get_playerdata=assert_get_playerdata_not_called,
+        get_playerdata=assert_not_called,
         get_estimated_winstreaks=custom_get_estimated_winstreaks,
     )
 
@@ -307,8 +306,8 @@ def test_real_overlay_controller_get_estimated_winstreaks_no_api() -> None:
         ),
         nick_database=NickDatabase([{}]),
         get_uuid=lambda username: f"uuid-{username}",
-        get_playerdata=assert_get_playerdata_not_called,
-        get_estimated_winstreaks=assert_get_estimated_winstreaks_not_called,
+        get_playerdata=assert_not_called,
+        get_estimated_winstreaks=assert_not_called,
     )
 
     winstreaks, accurate = controller.get_estimated_winstreaks("test-uuid")
@@ -327,8 +326,8 @@ def test_real_overlay_controller_get_estimated_winstreaks_no_key() -> None:
         ),
         nick_database=NickDatabase([{}]),
         get_uuid=lambda username: f"uuid-{username}",
-        get_playerdata=assert_get_playerdata_not_called,
-        get_estimated_winstreaks=assert_get_estimated_winstreaks_not_called,
+        get_playerdata=assert_not_called,
+        get_estimated_winstreaks=assert_not_called,
     )
 
     winstreaks, accurate = controller.get_estimated_winstreaks("test-uuid")

--- a/tests/prism/overlay/test_controller.py
+++ b/tests/prism/overlay/test_controller.py
@@ -25,7 +25,7 @@ def test_real_overlay_controller() -> None:
             use_antisniper_api=True,
         ),
         nick_database=NickDatabase([{}]),
-        get_uuid=lambda username: f"uuid-{username}",
+        get_uuid=assert_not_called,
         get_playerdata=assert_not_called,
         get_estimated_winstreaks=assert_not_called,
     )
@@ -42,7 +42,7 @@ def test_real_overlay_controller_no_antisniper_key() -> None:
             use_antisniper_api=True,
         ),
         nick_database=NickDatabase([{}]),
-        get_uuid=lambda username: f"uuid-{username}",
+        get_uuid=assert_not_called,
         get_playerdata=assert_not_called,
         get_estimated_winstreaks=assert_not_called,
     )
@@ -118,7 +118,7 @@ def test_real_overlay_controller_get_playerdata() -> None:
             user_id="1234",
         ),
         nick_database=NickDatabase([{}]),
-        get_uuid=lambda username: f"uuid-{username}",
+        get_uuid=assert_not_called,
         get_playerdata=mock_get_playerdata,
         get_estimated_winstreaks=assert_not_called,
     )
@@ -217,7 +217,7 @@ def test_real_overlay_controller_get_playerdata_dependency_injection() -> None:
         state=create_state(),
         settings=make_settings(user_id="test-user-id"),
         nick_database=NickDatabase([{}]),
-        get_uuid=lambda username: f"uuid-{username}",
+        get_uuid=assert_not_called,
         get_playerdata=custom_get_playerdata,
         get_estimated_winstreaks=assert_not_called,
     )
@@ -267,7 +267,7 @@ def test_real_overlay_controller_get_estimated_winstreaks_dependency_injection()
             use_antisniper_api=True,
         ),
         nick_database=NickDatabase([{}]),
-        get_uuid=lambda username: f"uuid-{username}",
+        get_uuid=assert_not_called,
         get_playerdata=assert_not_called,
         get_estimated_winstreaks=custom_get_estimated_winstreaks,
     )
@@ -305,7 +305,7 @@ def test_real_overlay_controller_get_estimated_winstreaks_no_api() -> None:
             use_antisniper_api=False,  # API is disabled
         ),
         nick_database=NickDatabase([{}]),
-        get_uuid=lambda username: f"uuid-{username}",
+        get_uuid=assert_not_called,
         get_playerdata=assert_not_called,
         get_estimated_winstreaks=assert_not_called,
     )
@@ -325,7 +325,7 @@ def test_real_overlay_controller_get_estimated_winstreaks_no_key() -> None:
             use_antisniper_api=True,
         ),
         nick_database=NickDatabase([{}]),
-        get_uuid=lambda username: f"uuid-{username}",
+        get_uuid=assert_not_called,
         get_playerdata=assert_not_called,
         get_estimated_winstreaks=assert_not_called,
     )

--- a/tests/prism/overlay/test_settings.py
+++ b/tests/prism/overlay/test_settings.py
@@ -439,7 +439,7 @@ def test_flush_settings_from_controller() -> None:
         state=create_state(),
         settings=settings,
         nick_database=NickDatabase([{}]),
-        get_uuid=lambda username: f"uuid-{username}",
+        get_uuid=assert_not_called,
         get_playerdata=assert_not_called,
         get_estimated_winstreaks=assert_not_called,
     )

--- a/tests/prism/overlay/test_settings.py
+++ b/tests/prism/overlay/test_settings.py
@@ -32,6 +32,7 @@ from tests.prism.overlay.utils import (
     CUSTOM_RATING_CONFIG_COLLECTION_DICT,
     DEFAULT_RATING_CONFIG_COLLECTION,
     DEFAULT_RATING_CONFIG_COLLECTION_DICT,
+    assert_not_called,
     make_dead_path,
     make_settings,
     no_close,
@@ -416,8 +417,6 @@ def test_flush_settings_from_controller() -> None:
     from prism.overlay.nick_database import NickDatabase
     from prism.overlay.real_controller import RealOverlayController
     from tests.prism.overlay.utils import (
-        assert_get_estimated_winstreaks_not_called,
-        assert_get_playerdata_not_called,
         create_state,
     )
 
@@ -441,8 +440,8 @@ def test_flush_settings_from_controller() -> None:
         settings=settings,
         nick_database=NickDatabase([{}]),
         get_uuid=lambda username: f"uuid-{username}",
-        get_playerdata=assert_get_playerdata_not_called,
-        get_estimated_winstreaks=assert_get_estimated_winstreaks_not_called,
+        get_playerdata=assert_not_called,
+        get_estimated_winstreaks=assert_not_called,
     )
 
     controller.store_settings()

--- a/tests/prism/overlay/utils.py
+++ b/tests/prism/overlay/utils.py
@@ -314,16 +314,9 @@ def missing_method(*args: Any, **kwargs: Any) -> Any:
     raise NotImplementedError
 
 
-def assert_get_playerdata_not_called(
-    uuid: str, user_id: str, key_holder: Any, api_limiter: Any
-) -> Any:
-    """Test helper that asserts if get_playerdata is unexpectedly called."""
-    assert False, "get_playerdata should not be called"
-
-
-def assert_get_estimated_winstreaks_not_called(uuid: str, key_holder: Any) -> Any:
-    """Test helper that asserts if get_estimated_winstreaks is unexpectedly called."""
-    assert False, "get_estimated_winstreaks should not be called"
+def assert_not_called(*args: Any, **kwargs: Any) -> Any:
+    """Test helper that asserts that the method is not called."""
+    assert False, "This function should not have been called"
 
 
 class ExtraAttributes(TypedDict):


### PR DESCRIPTION
Since we don't really care about type safety here - as the method should
never get called - we can make a singe helper that asserts this, instead
of specific ones for each method.
