### PR TITLE
chore: Replace mocked controller with real controller in tests (#39)

### DIFF
--- a/tests/prism/overlay/test_behaviour.py
+++ b/tests/prism/overlay/test_behaviour.py
@@ -3,7 +3,7 @@ import queue
 import unittest.mock
 from collections.abc import Mapping
 from dataclasses import dataclass, replace
-from typing import cast
+from typing import Any, cast
 
 import pytest
 
@@ -17,21 +17,24 @@ from prism.overlay.behaviour import (
 )
 from prism.overlay.controller import OverlayController
 from prism.overlay.keybinds import AlphanumericKeyDict
+from prism.overlay.nick_database import NickDatabase
+from prism.overlay.real_controller import RealOverlayController
 from prism.overlay.settings import (
     NickValue,
     Settings,
     SettingsDict,
     get_settings,
 )
-from prism.player import MISSING_WINSTREAKS
+from prism.player import MISSING_WINSTREAKS, Winstreaks
 from tests.prism.overlay import test_get_stats
+from tests.prism.overlay.test_get_stats import CURRENT_TIME_MS
 from tests.prism.overlay.test_settings import (
     DEFAULT_STATS_THREAD_COUNT,
     noop_update_settings,
 )
 from tests.prism.overlay.utils import (
     CUSTOM_RATING_CONFIG_COLLECTION_DICT,
-    MockedController,
+    create_controller,
     create_state,
     make_player,
     make_settings,
@@ -65,7 +68,7 @@ def test_set_nickname(known_nicks: dict[str, str]) -> None:
     """Assert that set_nickname works when setting a nick"""
     settings_file = no_close(io.StringIO())
 
-    controller = MockedController(
+    controller = create_controller(
         get_uuid=lambda username: UUID,
         settings=make_settings(write_settings_file_utf8=lambda: settings_file),
     )
@@ -134,7 +137,7 @@ def test_unset_nickname(known_nicks: dict[str, str], explicit: bool) -> None:
     """
     settings_file = no_close(io.StringIO())
 
-    controller = MockedController(
+    controller = create_controller(
         get_uuid=lambda username: UUID if explicit else None,
         settings=make_settings(write_settings_file_utf8=lambda: settings_file),
     )
@@ -181,7 +184,7 @@ def test_unset_nickname(known_nicks: dict[str, str], explicit: bool) -> None:
 def test_should_redraw(
     redraw_event_set: bool, completed_stats: tuple[str], result: bool
 ) -> None:
-    controller = MockedController(
+    controller = create_controller(
         state=create_state(
             lobby_players={"OwnUsername", "Player1", "Player2"}, in_queue=True
         )
@@ -230,28 +233,60 @@ def test_get_and_cache_stats(
         if winstreak_api_enabled
         else replace(base_user, playerdata=playerdata_without_winstreaks)
     )
-    controller = test_get_stats.make_scenario_controller(user)
+    assert user.nick is not None  # For typing
 
-    controller.get_estimated_winstreaks = lambda uuid: (
-        (
-            make_winstreaks(overall=100, solo=100, doubles=100, threes=100, fours=100),
-            True,
-        )
-        if estimated_winstreaks
-        else (MISSING_WINSTREAKS, False)
+    def get_estimated_winstreaks(
+        uuid: str, antisniper_key_holder: Any
+    ) -> tuple[Winstreaks, bool]:
+        assert uuid == user.uuid
+
+        if estimated_winstreaks:
+            return (
+                make_winstreaks(
+                    overall=100, solo=100, doubles=100, threes=100, fours=100
+                ),
+                True,
+            )
+
+        return (MISSING_WINSTREAKS, False)
+
+    def get_uuid(username: str) -> str | None:
+        if username == user.nick:
+            return None
+
+        assert username == user.username
+        return user.uuid
+
+    def get_playerdata(
+        uuid: str, user_id: str, antisniper_key_holder: Any, api_limiter: Any
+    ) -> Mapping[str, object]:
+        assert uuid == user.uuid
+        assert user.playerdata is not None
+        return user.playerdata
+
+    def get_time_ns() -> int:
+        return CURRENT_TIME_MS * 1_000_000
+
+    controller = create_controller(
+        get_uuid=get_uuid,
+        get_playerdata=get_playerdata,
+        get_time_ns=get_time_ns,
+        get_estimated_winstreaks=get_estimated_winstreaks,
+        nick_database=NickDatabase([{user.nick: user.uuid}]),
+        settings=make_settings(
+            use_antisniper_api=True,  # Always enable antisniper API for testing
+            antisniper_api_key="test_key",
+        ),
     )
 
     completed_queue = queue.Queue[str]()
-
-    # For typing
-    assert user.nick is not None
 
     get_stats_and_winstreak(user.nick, completed_queue, controller)
 
     # One update for getting the stats
     assert completed_queue.get_nowait() == user.nick
 
-    # One update for getting estimated winstreaks
+    # One update for getting estimated winstreaks - only when missing + gotten
     if not winstreak_api_enabled and estimated_winstreaks:
         assert completed_queue.get_nowait() == user.nick
     else:
@@ -261,7 +296,7 @@ def test_get_and_cache_stats(
 
 def test_update_settings_nothing() -> None:
     settings_file = no_close(io.StringIO())
-    controller = MockedController(
+    controller = create_controller(
         settings=make_settings(write_settings_file_utf8=lambda: settings_file),
     )
     settings_before = replace(controller.settings)
@@ -285,7 +320,7 @@ def test_update_settings_nothing() -> None:
 def test_update_settings_known_nicks() -> None:
     settings_file = no_close(io.StringIO())
 
-    controller = MockedController(
+    controller = create_controller(
         settings=make_settings(
             known_nicks={
                 "SuperbNick": {"uuid": "2", "comment": "2"},
@@ -344,7 +379,7 @@ def test_update_settings_everything_changed() -> None:
         write_settings_file_utf8=lambda: settings_file,
     )
 
-    controller = MockedController(
+    controller = create_controller(
         settings=settings, api_key_invalid=True, api_key_throttled=True
     )
 
@@ -425,7 +460,7 @@ def test_update_settings_everything_changed() -> None:
 
 
 def test_update_settings_clear_antisniper_key() -> None:
-    controller = MockedController(
+    controller = create_controller(
         settings=make_settings(antisniper_api_key="my-api-key")
     )
     controller.player_cache.clear_cache = unittest.mock.MagicMock()  # type: ignore
@@ -440,11 +475,11 @@ def test_update_settings_clear_antisniper_key() -> None:
     # Updated antisniper key -> should redraw
     assert controller.redraw_event.is_set()
 
-    assert controller.extra["antisniper_api_key"] is None
+    assert controller.antisniper_key_holder is None
 
 
 def test_update_settings_set_antisniper_key() -> None:
-    controller = MockedController(settings=make_settings(antisniper_api_key=None))
+    controller = create_controller(settings=make_settings(antisniper_api_key=None))
     controller.player_cache.clear_cache = unittest.mock.MagicMock()  # type: ignore
 
     new_settings = replace(
@@ -459,7 +494,8 @@ def test_update_settings_set_antisniper_key() -> None:
     # Updated antisniper key -> should redraw
     assert controller.redraw_event.is_set()
 
-    assert controller.extra["antisniper_api_key"] == "my-new-antisniper-api-key"
+    assert controller.antisniper_key_holder is not None
+    assert controller.antisniper_key_holder.key == "my-new-antisniper-api-key"
 
 
 @dataclass(frozen=True, slots=True)
@@ -911,7 +947,7 @@ def test_autodenick_teammate(
     def get_uuid(username: str) -> str:
         return f"uuid-for-{username}"
 
-    controller = MockedController(
+    controller = create_controller(
         state=create_state(
             lobby_players=lobby_players,
             party_members=party_members,
@@ -968,18 +1004,18 @@ def test_autodenick_teammate(
 @pytest.mark.parametrize(
     "controller",
     (
-        MockedController(state=create_state(in_queue=False)),
-        MockedController(state=create_state(out_of_sync=True)),
-        MockedController(api_key_invalid=True),
-        MockedController(api_key_throttled=True),
-        MockedController(
+        create_controller(state=create_state(in_queue=False)),
+        create_controller(state=create_state(out_of_sync=True)),
+        create_controller(api_key_invalid=True),
+        create_controller(api_key_throttled=True),
+        create_controller(
             state=create_state(in_queue=False, out_of_sync=True),
             api_key_invalid=True,
             api_key_throttled=True,
         ),
     ),
 )
-def test_autodenick_teammate_early_exit(controller: MockedController) -> None:
+def test_autodenick_teammate_early_exit(controller: RealOverlayController) -> None:
     with unittest.mock.patch(
         "prism.overlay.behaviour.set_nickname"
     ) as patched_set_nickname:
@@ -989,7 +1025,7 @@ def test_autodenick_teammate_early_exit(controller: MockedController) -> None:
 
 
 def test_autodenick_alive_players_mismatch() -> None:
-    controller = MockedController(
+    controller = create_controller(
         state=create_state(
             lobby_players={
                 "SomeNick",
@@ -1024,7 +1060,7 @@ def test_autodenick_alive_players_mismatch() -> None:
 
 
 def test_bedwars_game_ended() -> None:
-    controller = MockedController()
+    controller = create_controller()
     controller.player_cache.clear_cache = unittest.mock.MagicMock()  # type: ignore
 
     bedwars_game_ended(controller)

--- a/tests/prism/overlay/test_settings.py
+++ b/tests/prism/overlay/test_settings.py
@@ -32,7 +32,7 @@ from tests.prism.overlay.utils import (
     CUSTOM_RATING_CONFIG_COLLECTION_DICT,
     DEFAULT_RATING_CONFIG_COLLECTION,
     DEFAULT_RATING_CONFIG_COLLECTION_DICT,
-    assert_not_called,
+    create_controller,
     make_dead_path,
     make_settings,
     no_close,
@@ -414,12 +414,6 @@ def test_read_settings_file_error() -> None:
 
 
 def test_flush_settings_from_controller() -> None:
-    from prism.overlay.nick_database import NickDatabase
-    from prism.overlay.real_controller import RealOverlayController
-    from tests.prism.overlay.utils import (
-        create_state,
-    )
-
     file = no_close(io.StringIO())
 
     settings = make_settings(write_settings_file_utf8=lambda: file)
@@ -435,15 +429,7 @@ def test_flush_settings_from_controller() -> None:
         != settings
     )
 
-    controller = RealOverlayController(
-        state=create_state(),
-        settings=settings,
-        nick_database=NickDatabase([{}]),
-        get_uuid=assert_not_called,
-        get_playerdata=assert_not_called,
-        get_estimated_winstreaks=assert_not_called,
-        get_time_ns=assert_not_called,
-    )
+    controller = create_controller(settings=settings)
 
     controller.store_settings()
 

--- a/tests/prism/overlay/test_threading.py
+++ b/tests/prism/overlay/test_threading.py
@@ -7,7 +7,7 @@ from prism.overlay.player_cache import PlayerCache
 from prism.overlay.threading import get_stat_list
 from prism.player import KnownPlayer, PendingPlayer, Player
 from tests.prism.overlay.utils import (
-    MockedController,
+    create_controller,
     create_state,
     make_player,
     make_settings,
@@ -42,44 +42,44 @@ FULL_CACHE = make_player_cache(paul, kynes, liet, piter, leto)
 
 
 def test_get_stat_list_no_redraw() -> None:
-    assert get_stat_list(MockedController(), EMPTY_QUEUE, queue.Queue[str]()) is None
+    assert get_stat_list(create_controller(), EMPTY_QUEUE, queue.Queue[str]()) is None
 
 
 @pytest.mark.parametrize(
     "controller, expected_requested_stats, result",
     (
         # No players in the lobby
-        (MockedController(), set(), []),
+        (create_controller(), set(), []),
         (
             # Cache miss -> Request and return pending
-            MockedController(state=create_state(lobby_players={"Paul"})),
+            create_controller(state=create_state(lobby_players={"Paul"})),
             {"Paul"},
             [make_player("pending", "Paul")],
         ),
         # Different kinds of players
         (
-            MockedController(
+            create_controller(
                 state=create_state(lobby_players={"Paul"}), player_cache=FULL_CACHE
             ),
             set(),
             [paul],
         ),
         (
-            MockedController(
+            create_controller(
                 state=create_state(lobby_players={"Kynes"}), player_cache=FULL_CACHE
             ),
             set(),
             [kynes],
         ),
         (
-            MockedController(
+            create_controller(
                 state=create_state(lobby_players={"Liet"}), player_cache=FULL_CACHE
             ),
             set(),
             [liet],
         ),
         (
-            MockedController(
+            create_controller(
                 state=create_state(lobby_players={"Leto"}), player_cache=FULL_CACHE
             ),
             set(),
@@ -87,13 +87,13 @@ def test_get_stat_list_no_redraw() -> None:
         ),
         (
             # Cache miss -> Request and return pending
-            MockedController(state=create_state(lobby_players={"Leto"})),
+            create_controller(state=create_state(lobby_players={"Leto"})),
             {"Leto"},
             [leto],
         ),
         (
             # Bunch of players, properly sorted
-            MockedController(
+            create_controller(
                 state=create_state(lobby_players={"Paul", "Kynes", "Piter", "Leto"}),
                 player_cache=FULL_CACHE,
             ),
@@ -102,7 +102,7 @@ def test_get_stat_list_no_redraw() -> None:
         ),
         (
             # Only show alive players
-            MockedController(
+            create_controller(
                 settings=make_settings(hide_dead_players=True),
                 state=create_state(
                     lobby_players={"Paul", "Kynes", "Piter", "Leto"},
@@ -115,7 +115,7 @@ def test_get_stat_list_no_redraw() -> None:
         ),
         (
             # Show all players
-            MockedController(
+            create_controller(
                 settings=make_settings(hide_dead_players=False),
                 state=create_state(
                     lobby_players={"Paul", "Kynes", "Piter", "Leto"},
@@ -128,7 +128,7 @@ def test_get_stat_list_no_redraw() -> None:
         ),
         (
             # Sort correctly wrt party
-            MockedController(
+            create_controller(
                 state=create_state(
                     lobby_players={"Paul", "Kynes", "Piter", "Leto"},
                     party_members={"Piter", "Paul"},
@@ -141,7 +141,7 @@ def test_get_stat_list_no_redraw() -> None:
         ),
         (
             # Cache miss on all
-            MockedController(
+            create_controller(
                 state=create_state(lobby_players={"Paul", "Kynes", "Piter", "Leto"}),
             ),
             {"Paul", "Kynes", "Piter", "Leto"},
@@ -154,7 +154,7 @@ def test_get_stat_list_no_redraw() -> None:
         ),
         (
             # Duplicate nicked player
-            MockedController(
+            create_controller(
                 state=create_state(
                     lobby_players={"Liet", "Kynes"},
                     party_members={"Liet"},
@@ -167,7 +167,7 @@ def test_get_stat_list_no_redraw() -> None:
         ),
         (
             # Duplicate nicked player, but nicked is pending
-            MockedController(
+            create_controller(
                 state=create_state(
                     lobby_players={"Liet", "Kynes"},
                     party_members={"Liet"},
@@ -181,7 +181,7 @@ def test_get_stat_list_no_redraw() -> None:
         ),
         (
             # Duplicate nicked player, but un-nicked is pending
-            MockedController(
+            create_controller(
                 state=create_state(
                     lobby_players={"Liet", "Kynes"},
                     party_members={"Liet"},


### PR DESCRIPTION
This entirely removes MockedController, and brings the tests totally in
line with the real behavior - up to injected dependencies.

This should hopefully make future changes to the controller less painful

Co-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>
