### PR TITLE
providers

### DIFF
--- a/src/prism/mojang.py
+++ b/src/prism/mojang.py
@@ -15,105 +15,114 @@ USERPROFILES_ENDPOINT = "https://api.mojang.com/users/profiles/minecraft"
 REQUEST_LIMIT, REQUEST_WINDOW = 600, 10 * 60  # Max requests per time window
 BURST_REQUEST_LIMIT, BURST_REQUEST_WINDOW = 50, 8  # Found by trial and error
 
-# Use a connection pool for the requests
-SESSION = make_prism_requests_session()
-
-
-# Be nice to the Mojang api :)
-limiter = RateLimiter(limit=REQUEST_LIMIT, window=REQUEST_WINDOW)
-burst_limiter = RateLimiter(limit=BURST_REQUEST_LIMIT, window=BURST_REQUEST_WINDOW)
-
-# TODO: implement a disk cache
-# TTL on this cache can be large because for a username to get a new uuid the user
-# must first change their ign, then, after 37 days, someone else can get the name
-LOWERCASE_UUID_CACHE: dict[str, str] = {}  # Mapping username.lower() -> uuid
-UUID_MUTEX = threading.Lock()
-
 
 def compare_uuids(uuid_1: str, uuid_2: str, /) -> bool:
     """Return True if the two uuids (dashed or not) are equal"""
     return uuid_1.replace("-", "") == uuid_2.replace("-", "")
 
 
-def _make_request(
-    *, username: str, last_try: bool
-) -> requests.Response:  # pragma: nocover
-    try:
-        # Uphold our prescribed rate-limits
-        with limiter, burst_limiter:
-            response = SESSION.get(f"{USERPROFILES_ENDPOINT}/{username}")
-    except SSLError as e:
-        if is_missing_local_issuer_error(e):
-            # Short circuit out of get_uuid
-            # NOTE: Remember to catch this exception in the caller
-            raise MissingLocalIssuerSSLError(
-                "Request to Mojang API failed due to missing local issuer cert"
+class MojangAccountProvider:
+    def __init__(self, *, retry_limit: int, initial_timeout: float) -> None:
+        self._retry_limit = retry_limit
+        self._initial_timeout = initial_timeout
+
+        # Use a connection pool for the requests
+        self._session = make_prism_requests_session()
+
+        # Be nice to the Mojang api :)
+        self._limiter = RateLimiter(limit=REQUEST_LIMIT, window=REQUEST_WINDOW)
+        self._burst_limiter = RateLimiter(
+            limit=BURST_REQUEST_LIMIT, window=BURST_REQUEST_WINDOW
+        )
+
+        # TODO: implement a disk cache
+        # TTL on this cache can be large because for a username to get a new uuid the
+        # user must first change their ign, then, after 37 days, someone else can get
+        # the name
+        # Mapping username.lower() -> uuid
+        self._lowercase_uuid_cache: dict[str, str] = {}
+        self._uuid_cache_mutex = threading.Lock()
+
+    def _make_request(
+        self, *, username: str, last_try: bool
+    ) -> requests.Response:  # pragma: nocover
+        try:
+            # Uphold our prescribed rate-limits
+            with self._limiter, self._burst_limiter:
+                response = self._session.get(f"{USERPROFILES_ENDPOINT}/{username}")
+        except SSLError as e:
+            if is_missing_local_issuer_error(e):
+                # Short circuit out of get_uuid
+                # NOTE: Remember to catch this exception in the caller
+                raise MissingLocalIssuerSSLError(
+                    "Request to Mojang API failed due to missing local issuer cert"
+                ) from e
+            raise ExecutionError(
+                "Request to Mojang API failed due to an unknown SSL error"
             ) from e
-        raise ExecutionError(
-            "Request to Mojang API failed due to an unknown SSL error"
-        ) from e
-    except RequestException as e:
-        raise ExecutionError(
-            "Request to Mojang API failed due to an unknown error"
-        ) from e
+        except RequestException as e:
+            raise ExecutionError(
+                "Request to Mojang API failed due to an unknown error"
+            ) from e
 
-    if (
-        response.status_code == 429
-        or response.status_code == 503
-        or response.status_code == 504
-    ) and not last_try:
-        raise ExecutionError("Request to Mojang API failed due to rate limit, retrying")
+        if (
+            response.status_code == 429
+            or response.status_code == 503
+            or response.status_code == 504
+        ) and not last_try:
+            raise ExecutionError(
+                "Request to Mojang API failed due to rate limit, retrying"
+            )
 
-    return response
+        return response
 
+    def get_uuid_for_username(self, username: str, /) -> str:  # pragma: nocover
+        """Get the uuid of the user"""
+        with self._uuid_cache_mutex:
+            cache_hit = self._lowercase_uuid_cache.get(username.lower(), None)
 
-def get_uuid(
-    username: str, retry_limit: int = 5, initial_timeout: float = 2
-) -> str:  # pragma: nocover
-    """Get the uuid of the user. None if not found."""
-    with UUID_MUTEX:
-        cache_hit = LOWERCASE_UUID_CACHE.get(username.lower(), None)
+        if cache_hit is not None:
+            return cache_hit
 
-    if cache_hit is not None:
-        return cache_hit
+        try:
+            response = execute_with_retry(
+                functools.partial(self._make_request, username=username),
+                retry_limit=self._retry_limit,
+                initial_timeout=self._initial_timeout,
+            )
+        except ExecutionError as e:
+            raise APIError(f"Request to Mojang API failed for {username=}.") from e
 
-    try:
-        response = execute_with_retry(
-            functools.partial(_make_request, username=username),
-            retry_limit=retry_limit,
-            initial_timeout=initial_timeout,
-        )
-    except ExecutionError as e:
-        raise APIError(f"Request to Mojang API failed for {username=}.") from e
+        if response.status_code == 404 or response.status_code == 204:
+            # Not found
+            raise PlayerNotFoundError(
+                f"Player with username {username} not found from Mojang API."
+            )
 
-    if response.status_code == 404 or response.status_code == 204:
-        # Not found
-        raise PlayerNotFoundError(
-            f"Player with username {username} not found from Mojang API."
-        )
+        if not response:
+            raise APIError(
+                "Request to Mojang API failed with status code "
+                f"{response.status_code}. Response: {response.text}"
+            )
 
-    if not response:
-        raise APIError(
-            f"Request to Mojang API failed with status code {response.status_code}. "
-            f"Response: {response.text}"
-        )
+        try:
+            response_json = response.json()
+        except JSONDecodeError as e:
+            raise APIError(
+                "Failed parsing the response from the Mojang API. "
+                f"Raw content: {response.text}"
+            ) from e
 
-    try:
-        response_json = response.json()
-    except JSONDecodeError as e:
-        raise APIError(
-            "Failed parsing the response from the Mojang API. "
-            f"Raw content: {response.text}"
-        ) from e
+        # reponse is {"id": "...", "name": "..."}
+        uuid = response_json.get("id", None)
 
-    # reponse is {"id": "...", "name": "..."}
-    uuid = response_json.get("id", None)
+        if not isinstance(uuid, str):
+            raise APIError(
+                f"Request to Mojang API returned wrong type for uuid {uuid=}"
+            )
 
-    if not isinstance(uuid, str):
-        raise APIError(f"Request to Mojang API returned wrong type for uuid {uuid=}")
+        # Set cache
+        with self._uuid_cache_mutex:
+            self._lowercase_uuid_cache[username.lower()] = uuid
 
-    # Set cache
-    with UUID_MUTEX:
-        LOWERCASE_UUID_CACHE[username.lower()] = uuid
-
-    return uuid
+        return uuid

--- a/src/prism/mojang.py
+++ b/src/prism/mojang.py
@@ -16,11 +16,6 @@ REQUEST_LIMIT, REQUEST_WINDOW = 600, 10 * 60  # Max requests per time window
 BURST_REQUEST_LIMIT, BURST_REQUEST_WINDOW = 50, 8  # Found by trial and error
 
 
-def compare_uuids(uuid_1: str, uuid_2: str, /) -> bool:
-    """Return True if the two uuids (dashed or not) are equal"""
-    return uuid_1.replace("-", "") == uuid_2.replace("-", "")
-
-
 class MojangAccountProvider:
     def __init__(self, *, retry_limit: int, initial_timeout: float) -> None:
         self._retry_limit = retry_limit

--- a/src/prism/overlay/__main__.py
+++ b/src/prism/overlay/__main__.py
@@ -66,16 +66,18 @@ def main() -> None:  # pragma: nocover
     nick_database = NickDatabase.from_disk([], default_database=default_database)
 
     # Import late so we can patch ssl certs in requests
-    from prism.mojang import get_uuid
+    from prism.mojang import MojangAccountProvider
     from prism.overlay.antisniper_api import get_estimated_winstreaks, get_playerdata
     from prism.overlay.controller import OverlayController
     from prism.overlay.process_loglines import process_loglines, prompt_and_read_logfile
+
+    account_provider = MojangAccountProvider(retry_limit=5, initial_timeout=2)
 
     controller = OverlayController(
         state=OverlayState(),
         settings=settings,
         nick_database=nick_database,
-        get_uuid=get_uuid,
+        account_provider=account_provider,
         get_playerdata=get_playerdata,
         get_estimated_winstreaks=get_estimated_winstreaks,
         get_time_ns=time.time_ns,

--- a/src/prism/overlay/__main__.py
+++ b/src/prism/overlay/__main__.py
@@ -76,7 +76,7 @@ def main() -> None:  # pragma: nocover
 
     account_provider = MojangAccountProvider(retry_limit=5, initial_timeout=2)
     player_provider = StrangePlayerProvider(retry_limit=5, initial_timeout=2)
-    winstreak_provider = AntiSniperWinstreakProvider()
+    winstreak_provider = AntiSniperWinstreakProvider(retry_limit=5, initial_timeout=2)
 
     controller = OverlayController(
         state=OverlayState(),

--- a/src/prism/overlay/__main__.py
+++ b/src/prism/overlay/__main__.py
@@ -67,18 +67,22 @@ def main() -> None:  # pragma: nocover
 
     # Import late so we can patch ssl certs in requests
     from prism.mojang import MojangAccountProvider
-    from prism.overlay.antisniper_api import get_estimated_winstreaks, get_playerdata
+    from prism.overlay.antisniper_api import (
+        StrangePlayerProvider,
+        get_estimated_winstreaks,
+    )
     from prism.overlay.controller import OverlayController
     from prism.overlay.process_loglines import process_loglines, prompt_and_read_logfile
 
     account_provider = MojangAccountProvider(retry_limit=5, initial_timeout=2)
+    player_provider = StrangePlayerProvider(retry_limit=5, initial_timeout=2)
 
     controller = OverlayController(
         state=OverlayState(),
         settings=settings,
         nick_database=nick_database,
         account_provider=account_provider,
-        get_playerdata=get_playerdata,
+        player_provider=player_provider,
         get_estimated_winstreaks=get_estimated_winstreaks,
         get_time_ns=time.time_ns,
     )

--- a/src/prism/overlay/__main__.py
+++ b/src/prism/overlay/__main__.py
@@ -68,14 +68,15 @@ def main() -> None:  # pragma: nocover
     # Import late so we can patch ssl certs in requests
     from prism.mojang import MojangAccountProvider
     from prism.overlay.antisniper_api import (
+        AntiSniperWinstreakProvider,
         StrangePlayerProvider,
-        get_estimated_winstreaks,
     )
     from prism.overlay.controller import OverlayController
     from prism.overlay.process_loglines import process_loglines, prompt_and_read_logfile
 
     account_provider = MojangAccountProvider(retry_limit=5, initial_timeout=2)
     player_provider = StrangePlayerProvider(retry_limit=5, initial_timeout=2)
+    winstreak_provider = AntiSniperWinstreakProvider()
 
     controller = OverlayController(
         state=OverlayState(),
@@ -83,7 +84,7 @@ def main() -> None:  # pragma: nocover
         nick_database=nick_database,
         account_provider=account_provider,
         player_provider=player_provider,
-        get_estimated_winstreaks=get_estimated_winstreaks,
+        winstreak_provider=winstreak_provider,
         get_time_ns=time.time_ns,
     )
 

--- a/src/prism/overlay/antisniper_api.py
+++ b/src/prism/overlay/antisniper_api.py
@@ -291,7 +291,11 @@ class AntiSniperWinstreakProvider:
                 f"Request to winstreak endpoint failed with status code "
                 f"{response.status_code} for {uuid=}. Response: {response.text}"
             )
-            return MISSING_WINSTREAKS, False
+            raise APIError(
+                f"Request to Antisniper API failed with status code "
+                f"{response.status_code} when getting winstreaks for player {uuid}. "
+                f"Response: {response.text}"
+            )
 
         try:
             response_json = response.json()
@@ -300,7 +304,7 @@ class AntiSniperWinstreakProvider:
                 "Failed parsing the response from the winstreak endpoint. "
                 f"Raw content: {response.text}"
             )
-            return MISSING_WINSTREAKS, False
+            raise APIError("Failed parsing the response from the winstreak endpoint. ")
 
         return parse_estimated_winstreaks_response(response_json)
 
@@ -336,7 +340,7 @@ def parse_estimated_winstreaks_response(
     """Parse the reponse from the winstreaks endpoint"""
     if not response_json.get("success", False):
         logger.error(f"Winstreak endpoint returned an error. Response: {response_json}")
-        return MISSING_WINSTREAKS, False
+        raise APIError("Winstreak endpoint returned an error.")
 
     # Getting the winstreaks
     winstreaks: dict[GamemodeName, int | None] = {}

--- a/src/prism/overlay/antisniper_api.py
+++ b/src/prism/overlay/antisniper_api.py
@@ -137,6 +137,7 @@ class StrangePlayerProvider:
     ) -> None:
         self._retry_limit = retry_limit
         self._initial_timeout = initial_timeout
+        self._session = make_prism_requests_session()
 
     def _make_playerdata_request(
         self,
@@ -149,7 +150,7 @@ class StrangePlayerProvider:
         try:
             # Uphold our prescribed rate-limits
             with api_limiter:
-                response = SESSION.get(url, headers={"X-User-Id": user_id})
+                response = self._session.get(url, headers={"X-User-Id": user_id})
         except SSLError as e:
             if is_missing_local_issuer_error(e):
                 # Short circuit out of get_playerdata

--- a/src/prism/overlay/antisniper_api.py
+++ b/src/prism/overlay/antisniper_api.py
@@ -272,6 +272,20 @@ class AntiSniperWinstreakProvider:
             logger.exception("Request to winstreaks endpoint reached max retries")
             return MISSING_WINSTREAKS, False
 
+        if response.status_code == 403:
+            raise APIKeyError(
+                f"Request to Antisniper API failed with status code "
+                f"{response.status_code}. Assumed invalid API key. "
+                f"Response: {response.text}"
+            )
+
+        if is_global_throttle_response(response) or response.status_code == 429:
+            raise APIThrottleError(
+                f"Request to AntiSniper API failed with status code "
+                f"{response.status_code}. Assumed due to API key throttle. "
+                f"Response: {response.text}"
+            )
+
         if not response:
             logger.error(
                 f"Request to winstreak endpoint failed with status code "

--- a/src/prism/overlay/antisniper_api.py
+++ b/src/prism/overlay/antisniper_api.py
@@ -321,7 +321,8 @@ class AntiSniperWinstreakProvider:
                 f"Checked too many offline players for {url}, retrying"
             )
 
-        if response.status_code == 429 and not last_try:
+        throttled = is_global_throttle_response(response) or response.status_code == 429
+        if throttled and not last_try:
             raise ExecutionError(
                 "Request to AntiSniper API failed due to ratelimit, retrying"
             )

--- a/src/prism/overlay/antisniper_api.py
+++ b/src/prism/overlay/antisniper_api.py
@@ -90,16 +90,6 @@ def is_checked_too_many_offline_players_response(
     return True
 
 
-class AntiSniperAPIKeyHolder:
-    """Class associating an api key with a RateLimiter instance"""
-
-    def __init__(
-        self, key: str, limit: int = REQUEST_LIMIT, window: float = REQUEST_WINDOW
-    ):
-        self.key = key
-        self.limiter = RateLimiter(limit=limit, window=window)
-
-
 class StrangePlayerProvider:
     def __init__(
         self,

--- a/src/prism/overlay/antisniper_api.py
+++ b/src/prism/overlay/antisniper_api.py
@@ -26,7 +26,7 @@ def is_global_throttle_response(response: requests.Response) -> bool:  # pragma:
     """
     Return True if the response is a 500: throttle
 
-    This means that the Hypixel API key is being ratelimited
+    This is a condition that can occur on the AntiSniper API
     """
     # We ignore the http status code
 

--- a/src/prism/overlay/behaviour.py
+++ b/src/prism/overlay/behaviour.py
@@ -2,7 +2,6 @@ import functools
 import logging
 import queue
 
-from prism.overlay.antisniper_api import AntiSniperAPIKeyHolder
 from prism.overlay.controller import ERROR_DURING_PROCESSING, OverlayController
 from prism.overlay.get_stats import get_bedwars_stats
 from prism.overlay.settings import SettingsDict
@@ -184,16 +183,6 @@ def update_settings(new_settings: SettingsDict, controller: OverlayController) -
     if antisniper_api_key_changed:
         controller.antisniper_api_key_throttled = False
         controller.antisniper_api_key_invalid = False
-
-        new_antisniper_key = new_settings["antisniper_api_key"]
-        if new_antisniper_key is None:
-            controller.antisniper_key_holder = None
-        elif controller.antisniper_key_holder is not None:
-            controller.antisniper_key_holder.key = new_antisniper_key
-        else:
-            controller.antisniper_key_holder = AntiSniperAPIKeyHolder(
-                new_antisniper_key
-            )
 
     # Update the player cache
     if potential_antisniper_updates:

--- a/src/prism/overlay/behaviour.py
+++ b/src/prism/overlay/behaviour.py
@@ -182,8 +182,8 @@ def update_settings(new_settings: SettingsDict, controller: OverlayController) -
 
     # Update the API key
     if antisniper_api_key_changed:
-        controller.api_key_throttled = False
-        controller.api_key_invalid = False
+        controller.antisniper_api_key_throttled = False
+        controller.antisniper_api_key_invalid = False
 
         new_antisniper_key = new_settings["antisniper_api_key"]
         if new_antisniper_key is None:
@@ -258,8 +258,8 @@ def autodenick_teammate(controller: OverlayController) -> None:
     state = controller.state
 
     if (
-        controller.api_key_invalid
-        or controller.api_key_throttled
+        controller.antisniper_api_key_invalid
+        or controller.antisniper_api_key_throttled
         or not state.in_queue
         or state.out_of_sync
     ):

--- a/src/prism/overlay/behaviour.py
+++ b/src/prism/overlay/behaviour.py
@@ -58,7 +58,7 @@ def set_nickname(
             # Add your new nick
             controller.settings.known_nicks[nick] = new_nick_value
 
-        controller.store_settings()
+        controller.settings.flush_to_disk()
 
     with controller.nick_database.mutex:
         # Delete your old nick if found
@@ -240,7 +240,7 @@ def update_settings(new_settings: SettingsDict, controller: OverlayController) -
 
     controller.settings.update_from(new_settings)
 
-    controller.store_settings()
+    controller.settings.flush_to_disk()
 
 
 def autodenick_teammate(controller: OverlayController) -> None:

--- a/src/prism/overlay/behaviour.py
+++ b/src/prism/overlay/behaviour.py
@@ -2,12 +2,12 @@ import functools
 import logging
 import queue
 
-from prism.mojang import compare_uuids
 from prism.overlay.antisniper_api import AntiSniperAPIKeyHolder
 from prism.overlay.controller import ERROR_DURING_PROCESSING, OverlayController
 from prism.overlay.get_stats import get_bedwars_stats
 from prism.overlay.settings import SettingsDict
 from prism.player import MISSING_WINSTREAKS, KnownPlayer, PendingPlayer
+from prism.uuid import compare_uuids
 
 logger = logging.getLogger(__name__)
 

--- a/src/prism/overlay/behaviour.py
+++ b/src/prism/overlay/behaviour.py
@@ -257,13 +257,8 @@ def autodenick_teammate(controller: OverlayController) -> None:
     # Store a persistent view to the current state
     state = controller.state
 
-    if (
-        controller.antisniper_api_key_invalid
-        or controller.antisniper_api_key_throttled
-        or not state.in_queue
-        or state.out_of_sync
-    ):
-        # We're not quite sure of the state of the lobby or the stats cache
+    if not state.in_queue or state.out_of_sync:
+        # We're not quite sure of the state of the lobby
         return
 
     # Teammates whose IGN is not present in the lobby

--- a/src/prism/overlay/controller.py
+++ b/src/prism/overlay/controller.py
@@ -127,8 +127,6 @@ class OverlayController:
             return 0, ERROR_DURING_PROCESSING
         except PlayerNotFoundError as e:
             logger.debug(f"Player not found on Hypixel: {uuid=}", exc_info=e)
-            self.antisniper_api_key_invalid = False
-            self.antisniper_api_key_throttled = False
             self.missing_local_issuer_certificate = False
             return 0, None
         except APIError as e:
@@ -136,20 +134,14 @@ class OverlayController:
             return 0, ERROR_DURING_PROCESSING
         except APIKeyError as e:
             logger.warning(f"Invalid API key getting stats for {uuid=}", exc_info=e)
-            self.antisniper_api_key_invalid = True
-            self.antisniper_api_key_throttled = False
             self.missing_local_issuer_certificate = False
             return 0, ERROR_DURING_PROCESSING
         except APIThrottleError as e:
             logger.warning(f"API key throttled getting stats for {uuid=}", exc_info=e)
-            self.antisniper_api_key_invalid = False
-            self.antisniper_api_key_throttled = True
             self.missing_local_issuer_certificate = False
             return 0, ERROR_DURING_PROCESSING
         else:
             dataReceivedAtMs = self._get_time_ns() // 1_000_000
-            self.antisniper_api_key_invalid = False
-            self.antisniper_api_key_throttled = False
             self.missing_local_issuer_certificate = False
             return dataReceivedAtMs, playerdata
 

--- a/src/prism/overlay/controller.py
+++ b/src/prism/overlay/controller.py
@@ -36,7 +36,7 @@ class OverlayController:
         state: "OverlayState",
         settings: "Settings",
         nick_database: "NickDatabase",
-        get_uuid: Callable[[str], str | None],
+        get_uuid: Callable[[str], str],
         get_playerdata: Callable[
             [str, str, "AntiSniperAPIKeyHolder | None", "RateLimiter"],
             Mapping[str, object],
@@ -79,6 +79,9 @@ class OverlayController:
     def get_uuid(self, username: str) -> str | None | ProcessingError:
         try:
             uuid = self._get_uuid(username)
+        except PlayerNotFoundError:
+            self.missing_local_issuer_certificate = False
+            return None
         except MissingLocalIssuerSSLError:
             logger.exception("get_uuid: missing local issuer cert")
             self.missing_local_issuer_certificate = True

--- a/src/prism/overlay/controller.py
+++ b/src/prism/overlay/controller.py
@@ -5,7 +5,6 @@ from enum import Enum
 from typing import TYPE_CHECKING, Protocol
 
 from prism.errors import APIError, APIKeyError, APIThrottleError, PlayerNotFoundError
-from prism.overlay.antisniper_api import AntiSniperAPIKeyHolder
 from prism.player import MISSING_WINSTREAKS, Winstreaks
 from prism.ssl_errors import MissingLocalIssuerSSLError
 
@@ -82,12 +81,6 @@ class OverlayController:
         self.redraw_event = threading.Event()
         self.update_presence_event = threading.Event()
         self.autowho_event = threading.Event()
-
-        self.antisniper_key_holder: AntiSniperAPIKeyHolder | None = (
-            AntiSniperAPIKeyHolder(settings.antisniper_api_key)
-            if settings.antisniper_api_key is not None
-            else None
-        )
 
         self._account_provider = account_provider
         self._player_provider = player_provider

--- a/src/prism/overlay/controller.py
+++ b/src/prism/overlay/controller.py
@@ -68,8 +68,9 @@ class OverlayController:
     ) -> None:
         from prism.overlay.player_cache import PlayerCache
 
-        self.api_key_invalid = False
-        self.api_key_throttled = False
+        self.antisniper_api_key_invalid = False
+        self.antisniper_api_key_throttled = False
+
         self.missing_local_issuer_certificate = False
 
         self.ready = False
@@ -126,8 +127,8 @@ class OverlayController:
             return 0, ERROR_DURING_PROCESSING
         except PlayerNotFoundError as e:
             logger.debug(f"Player not found on Hypixel: {uuid=}", exc_info=e)
-            self.api_key_invalid = False
-            self.api_key_throttled = False
+            self.antisniper_api_key_invalid = False
+            self.antisniper_api_key_throttled = False
             self.missing_local_issuer_certificate = False
             return 0, None
         except APIError as e:
@@ -135,20 +136,20 @@ class OverlayController:
             return 0, ERROR_DURING_PROCESSING
         except APIKeyError as e:
             logger.warning(f"Invalid API key getting stats for {uuid=}", exc_info=e)
-            self.api_key_invalid = True
-            self.api_key_throttled = False
+            self.antisniper_api_key_invalid = True
+            self.antisniper_api_key_throttled = False
             self.missing_local_issuer_certificate = False
             return 0, ERROR_DURING_PROCESSING
         except APIThrottleError as e:
             logger.warning(f"API key throttled getting stats for {uuid=}", exc_info=e)
-            self.api_key_invalid = False
-            self.api_key_throttled = True
+            self.antisniper_api_key_invalid = False
+            self.antisniper_api_key_throttled = True
             self.missing_local_issuer_certificate = False
             return 0, ERROR_DURING_PROCESSING
         else:
             dataReceivedAtMs = self._get_time_ns() // 1_000_000
-            self.api_key_invalid = False
-            self.api_key_throttled = False
+            self.antisniper_api_key_invalid = False
+            self.antisniper_api_key_throttled = False
             self.missing_local_issuer_certificate = False
             return dataReceivedAtMs, playerdata
 

--- a/src/prism/overlay/controller.py
+++ b/src/prism/overlay/controller.py
@@ -40,7 +40,6 @@ class PlayerProvider(Protocol):
         uuid: str,
         *,
         user_id: str,
-        antisniper_key_holder: "AntiSniperAPIKeyHolder | None",
         limiter: "RateLimiter",
     ) -> Mapping[str, object]: ...
 
@@ -114,7 +113,6 @@ class OverlayController:
             playerdata = self._player_provider.get_playerdata_for_uuid(
                 uuid=uuid,
                 user_id=self.settings.user_id,
-                antisniper_key_holder=self.antisniper_key_holder,
                 limiter=self.api_limiter,
             )
         except MissingLocalIssuerSSLError:

--- a/src/prism/overlay/controller.py
+++ b/src/prism/overlay/controller.py
@@ -153,6 +153,3 @@ class OverlayController:
         # TODO: The controller should handle errors raised by
         # self._get_estimated_winstreaks
         return self._get_estimated_winstreaks(uuid, self.antisniper_key_holder)
-
-    def store_settings(self) -> None:
-        self.settings.flush_to_disk()

--- a/src/prism/overlay/controller.py
+++ b/src/prism/overlay/controller.py
@@ -152,9 +152,7 @@ class OverlayController:
             self.missing_local_issuer_certificate = False
             return dataReceivedAtMs, playerdata
 
-    def get_estimated_winstreaks(
-        self, uuid: str
-    ) -> tuple[Winstreaks, bool]:  # pragma: no cover
+    def get_estimated_winstreaks(self, uuid: str) -> tuple[Winstreaks, bool]:
         if (
             not self.settings.use_antisniper_api
             or self.settings.antisniper_api_key is None

--- a/src/prism/overlay/controller.py
+++ b/src/prism/overlay/controller.py
@@ -48,8 +48,11 @@ class WinstreakProvider(Protocol):
         self,
         uuid: str,
         *,
-        antisniper_key_holder: AntiSniperAPIKeyHolder,
+        antisniper_api_key: str,
     ) -> tuple[Winstreaks, bool]: ...
+
+    @property
+    def seconds_until_unblocked(self) -> float: ...
 
 
 class OverlayController:
@@ -152,10 +155,13 @@ class OverlayController:
     def get_estimated_winstreaks(
         self, uuid: str
     ) -> tuple[Winstreaks, bool]:  # pragma: no cover
-        if not self.settings.use_antisniper_api or self.antisniper_key_holder is None:
+        if (
+            not self.settings.use_antisniper_api
+            or self.settings.antisniper_api_key is None
+        ):
             return MISSING_WINSTREAKS, False
 
         # TODO: The controller should handle errors raised here
         return self._winstreak_provider.get_estimated_winstreaks_for_uuid(
-            uuid, antisniper_key_holder=self.antisniper_key_holder
+            uuid, antisniper_api_key=self.settings.antisniper_api_key
         )

--- a/src/prism/overlay/controller.py
+++ b/src/prism/overlay/controller.py
@@ -125,6 +125,7 @@ class OverlayController:
         except APIError as e:
             logger.error(f"Hypixel API error getting stats for {uuid=}", exc_info=e)
             return 0, ERROR_DURING_PROCESSING
+        # TODO: Remove api key errors once we move to flashlight provider
         except APIKeyError as e:
             logger.warning(f"Invalid API key getting stats for {uuid=}", exc_info=e)
             self.missing_local_issuer_certificate = False

--- a/src/prism/overlay/output/overlay/run_overlay.py
+++ b/src/prism/overlay/output/overlay/run_overlay.py
@@ -61,13 +61,8 @@ def run_overlay(
                 )
             )
 
-        antisniper_block_duration_seconds = (
-            controller.antisniper_key_holder.limiter.block_duration_seconds
-            if controller.antisniper_key_holder is not None
-            else 0
-        )
         block_duration_seconds = max(
-            antisniper_block_duration_seconds,
+            controller._winstreak_provider.seconds_until_unblocked,
             controller._player_provider.seconds_until_unblocked,
         )
 

--- a/src/prism/overlay/output/overlay/run_overlay.py
+++ b/src/prism/overlay/output/overlay/run_overlay.py
@@ -55,7 +55,10 @@ def run_overlay(
         if controller.antisniper_api_key_invalid:
             info_cells.append(
                 InfoCellValue(
-                    text="Invalid API key. Get a new one from antisniper.net",
+                    text=(
+                        "Invalid AntiSniper API key. "
+                        "Get a new one from antisniper.net"
+                    ),
                     color="red" if time.monotonic() % 2 > 1 else "white",
                     url=None,
                 )
@@ -92,7 +95,7 @@ def run_overlay(
         if controller.antisniper_api_key_throttled:
             info_cells.append(
                 InfoCellValue(
-                    text="Hypixel ratelimit reached! Wait time ~1 min.",
+                    text="AntiSniper ratelimit reached! Wait time ~1 min.",
                     color="orange" if time.monotonic() % 2 > 1 else "white",
                     url=None,
                 )

--- a/src/prism/overlay/output/overlay/run_overlay.py
+++ b/src/prism/overlay/output/overlay/run_overlay.py
@@ -68,7 +68,7 @@ def run_overlay(
         )
         block_duration_seconds = max(
             antisniper_block_duration_seconds,
-            controller.api_limiter.block_duration_seconds,
+            controller._player_provider.seconds_until_unblocked,
         )
 
         if block_duration_seconds > 0:

--- a/src/prism/overlay/output/overlay/run_overlay.py
+++ b/src/prism/overlay/output/overlay/run_overlay.py
@@ -52,7 +52,7 @@ def run_overlay(
                 )
             )
 
-        if controller.api_key_invalid:
+        if controller.antisniper_api_key_invalid:
             info_cells.append(
                 InfoCellValue(
                     text="Invalid API key. Get a new one from antisniper.net",
@@ -89,7 +89,7 @@ def run_overlay(
                 )
             )
 
-        if controller.api_key_throttled:
+        if controller.antisniper_api_key_throttled:
             info_cells.append(
                 InfoCellValue(
                     text="Hypixel ratelimit reached! Wait time ~1 min.",

--- a/src/prism/stats.py
+++ b/src/prism/stats.py
@@ -168,8 +168,7 @@ def print_bedwars_stats(
 def get_and_display(username: str) -> None:
     try:
         uuid = get_uuid(username)
-        nick = None
-    except APIError:
+    except (APIError, PlayerNotFoundError):
         uuid = None
 
     if uuid is None:
@@ -186,7 +185,7 @@ def get_and_display(username: str) -> None:
     ) as e:
         print(e)
     else:
-        print_bedwars_stats(playerdata, nick=nick)
+        print_bedwars_stats(playerdata, nick=None)
 
 
 def main() -> None:

--- a/src/prism/stats.py
+++ b/src/prism/stats.py
@@ -20,11 +20,13 @@ from prism.hypixel import (
     get_gamemode_stats,
     get_player_data,
 )
-from prism.mojang import get_uuid
+from prism.mojang import MojangAccountProvider
 from prism.utils import div, format_seconds, read_key, truncate_float
 
 api_key = read_key(Path(sys.path[0]) / "api_key")
 key_holder = HypixelAPIKeyHolder(api_key)
+
+ACCOUNT_PROVIDER = MojangAccountProvider(retry_limit=0, initial_timeout=0)
 
 
 SEP = " " * 4
@@ -167,7 +169,7 @@ def print_bedwars_stats(
 
 def get_and_display(username: str) -> None:
     try:
-        uuid = get_uuid(username)
+        uuid = ACCOUNT_PROVIDER.get_uuid_for_username(username)
     except (APIError, PlayerNotFoundError):
         uuid = None
 

--- a/src/prism/uuid.py
+++ b/src/prism/uuid.py
@@ -1,0 +1,3 @@
+def compare_uuids(uuid_1: str, uuid_2: str, /) -> bool:
+    """Return True if the two uuids (dashed or not) are equal"""
+    return uuid_1.replace("-", "") == uuid_2.replace("-", "")

--- a/tests/prism/overlay/test_antisniper_api.py
+++ b/tests/prism/overlay/test_antisniper_api.py
@@ -5,6 +5,7 @@ import pytest
 from prism.overlay.antisniper_api import (
     STATS_ENDPOINT,
     AntiSniperAPIKeyHolder,
+    StrangePlayerProvider,
     parse_estimated_winstreaks_response,
 )
 from prism.player import MISSING_WINSTREAKS, Winstreaks
@@ -114,3 +115,7 @@ def test_antisniper_key_holder() -> None:
 def test_stats_endpoint() -> None:
     # Make sure we don't release a version using the test endpoint
     assert STATS_ENDPOINT == "https://flashlight.recdep.no"
+
+
+def test_strange_player_provider() -> None:
+    StrangePlayerProvider(retry_limit=3, initial_timeout=1.0)

--- a/tests/prism/overlay/test_antisniper_api.py
+++ b/tests/prism/overlay/test_antisniper_api.py
@@ -5,6 +5,7 @@ import pytest
 from prism.overlay.antisniper_api import (
     STATS_ENDPOINT,
     AntiSniperAPIKeyHolder,
+    AntiSniperWinstreakProvider,
     StrangePlayerProvider,
     parse_estimated_winstreaks_response,
 )
@@ -119,4 +120,9 @@ def test_stats_endpoint() -> None:
 
 def test_strange_player_provider() -> None:
     provider = StrangePlayerProvider(retry_limit=3, initial_timeout=1.0)
+    assert provider.seconds_until_unblocked == 0.0
+
+
+def test_antisniper_winstreak_provider() -> None:
+    provider = AntiSniperWinstreakProvider(retry_limit=3, initial_timeout=1.0)
     assert provider.seconds_until_unblocked == 0.0

--- a/tests/prism/overlay/test_antisniper_api.py
+++ b/tests/prism/overlay/test_antisniper_api.py
@@ -118,4 +118,5 @@ def test_stats_endpoint() -> None:
 
 
 def test_strange_player_provider() -> None:
-    StrangePlayerProvider(retry_limit=3, initial_timeout=1.0)
+    provider = StrangePlayerProvider(retry_limit=3, initial_timeout=1.0)
+    assert provider.seconds_until_unblocked == 0.0

--- a/tests/prism/overlay/test_antisniper_api.py
+++ b/tests/prism/overlay/test_antisniper_api.py
@@ -5,7 +5,6 @@ import pytest
 from prism.errors import APIError
 from prism.overlay.antisniper_api import (
     STATS_ENDPOINT,
-    AntiSniperAPIKeyHolder,
     AntiSniperWinstreakProvider,
     StrangePlayerProvider,
     parse_estimated_winstreaks_response,
@@ -120,10 +119,6 @@ def test_parse_estimated_winstreaks_response(
         winstreaks,
         winstreaks_accurate,
     )
-
-
-def test_antisniper_key_holder() -> None:
-    AntiSniperAPIKeyHolder(key="sdlfksjdflk", limit=10, window=1.5)
 
 
 def test_stats_endpoint() -> None:

--- a/tests/prism/overlay/test_behaviour.py
+++ b/tests/prism/overlay/test_behaviour.py
@@ -34,6 +34,7 @@ from tests.prism.overlay.test_settings import (
 )
 from tests.prism.overlay.utils import (
     CUSTOM_RATING_CONFIG_COLLECTION_DICT,
+    MockedAccountProvider,
     create_controller,
     create_state,
     make_player,
@@ -69,7 +70,9 @@ def test_set_nickname(known_nicks: dict[str, str]) -> None:
     settings_file = no_close(io.StringIO())
 
     controller = create_controller(
-        get_uuid=lambda username: UUID,
+        account_provider=MockedAccountProvider(
+            get_uuid_for_username=lambda username: UUID
+        ),
         settings=make_settings(write_settings_file_utf8=lambda: settings_file),
     )
     controller.player_cache.uncache_player = unittest.mock.MagicMock()  # type: ignore
@@ -144,7 +147,7 @@ def test_unset_nickname(known_nicks: dict[str, str], explicit: bool) -> None:
         raise PlayerNotFoundError
 
     controller = create_controller(
-        get_uuid=get_uuid,
+        account_provider=MockedAccountProvider(get_uuid_for_username=get_uuid),
         settings=make_settings(write_settings_file_utf8=lambda: settings_file),
     )
     controller.player_cache.uncache_player = unittest.mock.MagicMock()  # type: ignore
@@ -274,7 +277,7 @@ def test_get_and_cache_stats(
         return CURRENT_TIME_MS * 1_000_000
 
     controller = create_controller(
-        get_uuid=get_uuid,
+        account_provider=MockedAccountProvider(get_uuid_for_username=get_uuid),
         get_playerdata=get_playerdata,
         get_time_ns=get_time_ns,
         get_estimated_winstreaks=get_estimated_winstreaks,
@@ -960,7 +963,7 @@ def test_autodenick_teammate(
             in_queue=True,
             out_of_sync=False,
         ),
-        get_uuid=get_uuid,
+        account_provider=MockedAccountProvider(get_uuid_for_username=get_uuid),
     )
 
     # Update the controller state by setting cache and denicks

--- a/tests/prism/overlay/test_behaviour.py
+++ b/tests/prism/overlay/test_behaviour.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 
 import pytest
 
+from prism.errors import PlayerNotFoundError
 from prism.overlay.behaviour import (
     autodenick_teammate,
     bedwars_game_ended,
@@ -136,8 +137,14 @@ def test_unset_nickname(known_nicks: dict[str, str], explicit: bool) -> None:
     """
     settings_file = no_close(io.StringIO())
 
+    def get_uuid(_: str) -> str:
+        if explicit:
+            return UUID
+
+        raise PlayerNotFoundError
+
     controller = create_controller(
-        get_uuid=lambda username: UUID if explicit else None,
+        get_uuid=get_uuid,
         settings=make_settings(write_settings_file_utf8=lambda: settings_file),
     )
     controller.player_cache.uncache_player = unittest.mock.MagicMock()  # type: ignore
@@ -249,9 +256,9 @@ def test_get_and_cache_stats(
 
         return (MISSING_WINSTREAKS, False)
 
-    def get_uuid(username: str) -> str | None:
+    def get_uuid(username: str) -> str:
         if username == user.nick:
-            return None
+            raise PlayerNotFoundError
 
         assert username == user.username
         return user.uuid

--- a/tests/prism/overlay/test_behaviour.py
+++ b/tests/prism/overlay/test_behaviour.py
@@ -475,7 +475,9 @@ def test_update_settings_everything_changed() -> None:
 
 def test_update_settings_clear_antisniper_key() -> None:
     controller = create_controller(
-        settings=make_settings(antisniper_api_key="my-api-key")
+        settings=make_settings(antisniper_api_key="my-api-key"),
+        antisniper_api_key_invalid=True,
+        antisniper_api_key_throttled=True,
     )
     controller.player_cache.clear_cache = unittest.mock.MagicMock()  # type: ignore
 
@@ -489,11 +491,16 @@ def test_update_settings_clear_antisniper_key() -> None:
     # Updated antisniper key -> should redraw
     assert controller.redraw_event.is_set()
 
-    assert controller.antisniper_key_holder is None
+    assert not controller.antisniper_api_key_invalid
+    assert not controller.antisniper_api_key_throttled
 
 
 def test_update_settings_set_antisniper_key() -> None:
-    controller = create_controller(settings=make_settings(antisniper_api_key=None))
+    controller = create_controller(
+        settings=make_settings(antisniper_api_key=None),
+        antisniper_api_key_invalid=True,
+        antisniper_api_key_throttled=True,
+    )
     controller.player_cache.clear_cache = unittest.mock.MagicMock()  # type: ignore
 
     new_settings = replace(
@@ -508,8 +515,8 @@ def test_update_settings_set_antisniper_key() -> None:
     # Updated antisniper key -> should redraw
     assert controller.redraw_event.is_set()
 
-    assert controller.antisniper_key_holder is not None
-    assert controller.antisniper_key_holder.key == "my-new-antisniper-api-key"
+    assert not controller.antisniper_api_key_invalid
+    assert not controller.antisniper_api_key_throttled
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/prism/overlay/test_behaviour.py
+++ b/tests/prism/overlay/test_behaviour.py
@@ -268,7 +268,7 @@ def test_get_and_cache_stats(
         return user.uuid
 
     def get_playerdata(
-        uuid: str, user_id: str, antisniper_key_holder: Any, api_limiter: Any
+        uuid: str, user_id: str, api_limiter: Any
     ) -> Mapping[str, object]:
         assert uuid == user.uuid
         assert user.playerdata is not None

--- a/tests/prism/overlay/test_behaviour.py
+++ b/tests/prism/overlay/test_behaviour.py
@@ -36,6 +36,7 @@ from tests.prism.overlay.utils import (
     CUSTOM_RATING_CONFIG_COLLECTION_DICT,
     MockedAccountProvider,
     MockedPlayerProvider,
+    MockedWinstreakProvider,
     create_controller,
     create_state,
     make_player,
@@ -279,7 +280,9 @@ def test_get_and_cache_stats(
         account_provider=MockedAccountProvider(get_uuid_for_username=get_uuid),
         player_provider=MockedPlayerProvider(get_playerdata_for_uuid=get_playerdata),
         get_time_ns=get_time_ns,
-        get_estimated_winstreaks=get_estimated_winstreaks,
+        winstreak_provider=MockedWinstreakProvider(
+            get_estimated_winstreaks_for_uuid=get_estimated_winstreaks
+        ),
         nick_database=NickDatabase([{user.nick: user.uuid}]),
         settings=make_settings(
             use_antisniper_api=True,  # Always enable antisniper API for testing

--- a/tests/prism/overlay/test_behaviour.py
+++ b/tests/prism/overlay/test_behaviour.py
@@ -3,7 +3,7 @@ import queue
 import unittest.mock
 from collections.abc import Mapping
 from dataclasses import dataclass, replace
-from typing import Any, cast
+from typing import cast
 
 import pytest
 
@@ -247,8 +247,9 @@ def test_get_and_cache_stats(
     assert user.nick is not None  # For typing
 
     def get_estimated_winstreaks(
-        uuid: str, antisniper_key_holder: Any
+        uuid: str, antisniper_api_key: str
     ) -> tuple[Winstreaks, bool]:
+        assert antisniper_api_key == "test_key"
         assert uuid == user.uuid
 
         if estimated_winstreaks:

--- a/tests/prism/overlay/test_behaviour.py
+++ b/tests/prism/overlay/test_behaviour.py
@@ -35,6 +35,7 @@ from tests.prism.overlay.test_settings import (
 from tests.prism.overlay.utils import (
     CUSTOM_RATING_CONFIG_COLLECTION_DICT,
     MockedAccountProvider,
+    MockedPlayerProvider,
     create_controller,
     create_state,
     make_player,
@@ -278,7 +279,7 @@ def test_get_and_cache_stats(
 
     controller = create_controller(
         account_provider=MockedAccountProvider(get_uuid_for_username=get_uuid),
-        get_playerdata=get_playerdata,
+        player_provider=MockedPlayerProvider(get_playerdata_for_uuid=get_playerdata),
         get_time_ns=get_time_ns,
         get_estimated_winstreaks=get_estimated_winstreaks,
         nick_database=NickDatabase([{user.nick: user.uuid}]),

--- a/tests/prism/overlay/test_behaviour.py
+++ b/tests/prism/overlay/test_behaviour.py
@@ -392,7 +392,9 @@ def test_update_settings_everything_changed() -> None:
     )
 
     controller = create_controller(
-        settings=settings, api_key_invalid=True, api_key_throttled=True
+        settings=settings,
+        antisniper_api_key_invalid=True,
+        antisniper_api_key_throttled=True,
     )
 
     # NOTE: Make sure everything specified here is different from its default value
@@ -467,8 +469,8 @@ def test_update_settings_everything_changed() -> None:
     # Lots of stuff changed, so we want to redraw
     assert controller.redraw_event.is_set()
 
-    assert not controller.api_key_invalid
-    assert not controller.api_key_throttled
+    assert not controller.antisniper_api_key_invalid
+    assert not controller.antisniper_api_key_throttled
 
 
 def test_update_settings_clear_antisniper_key() -> None:
@@ -1018,12 +1020,12 @@ def test_autodenick_teammate(
     (
         create_controller(state=create_state(in_queue=False)),
         create_controller(state=create_state(out_of_sync=True)),
-        create_controller(api_key_invalid=True),
-        create_controller(api_key_throttled=True),
+        create_controller(antisniper_api_key_invalid=True),
+        create_controller(antisniper_api_key_throttled=True),
         create_controller(
             state=create_state(in_queue=False, out_of_sync=True),
-            api_key_invalid=True,
-            api_key_throttled=True,
+            antisniper_api_key_invalid=True,
+            antisniper_api_key_throttled=True,
         ),
     ),
 )

--- a/tests/prism/overlay/test_behaviour.py
+++ b/tests/prism/overlay/test_behaviour.py
@@ -267,9 +267,7 @@ def test_get_and_cache_stats(
         assert username == user.username
         return user.uuid
 
-    def get_playerdata(
-        uuid: str, user_id: str, api_limiter: Any
-    ) -> Mapping[str, object]:
+    def get_playerdata(uuid: str, user_id: str) -> Mapping[str, object]:
         assert uuid == user.uuid
         assert user.playerdata is not None
         return user.playerdata

--- a/tests/prism/overlay/test_controller.py
+++ b/tests/prism/overlay/test_controller.py
@@ -118,16 +118,12 @@ def test_real_overlay_controller_get_playerdata() -> None:
     assert playerdata is None
 
     error = APIKeyError()
-    assert not controller.antisniper_api_key_invalid
     _, playerdata = controller.get_playerdata("uuid")
     assert playerdata is ERROR_DURING_PROCESSING
-    assert controller.antisniper_api_key_invalid
 
     error = APIThrottleError()
-    assert not controller.antisniper_api_key_throttled
     _, playerdata = controller.get_playerdata("uuid")
     assert playerdata is ERROR_DURING_PROCESSING
-    assert controller.antisniper_api_key_throttled
 
     error = MissingLocalIssuerSSLError()
     assert not controller.missing_local_issuer_certificate
@@ -141,8 +137,6 @@ def test_real_overlay_controller_get_playerdata() -> None:
     assert playerdata is returned_playerdata
     assert dataReceivedAtMs == 1234567890123456789 // 1_000_000
 
-    assert not controller.antisniper_api_key_invalid
-    assert not controller.antisniper_api_key_throttled
     assert not controller.missing_local_issuer_certificate
 
 

--- a/tests/prism/overlay/test_controller.py
+++ b/tests/prism/overlay/test_controller.py
@@ -1,7 +1,6 @@
 from collections.abc import Mapping
 
 from prism.errors import APIError, APIKeyError, APIThrottleError, PlayerNotFoundError
-from prism.overlay.antisniper_api import AntiSniperAPIKeyHolder
 from prism.overlay.controller import ERROR_DURING_PROCESSING
 from prism.player import MISSING_WINSTREAKS, Winstreaks
 from prism.ssl_errors import MissingLocalIssuerSSLError
@@ -194,11 +193,10 @@ def test_real_overlay_controller_get_estimated_winstreaks_dependency_injection()
     custom_accurate = True
 
     def custom_get_estimated_winstreaks(
-        uuid: str, key_holder: AntiSniperAPIKeyHolder
+        uuid: str, antisniper_api_key: str
     ) -> tuple[Winstreaks, bool]:
         assert uuid == "test-uuid"
-        assert key_holder is not None
-        assert key_holder.key == "test-api-key"
+        assert antisniper_api_key == "test-api-key"
         return custom_winstreaks, custom_accurate
 
     controller = create_controller(

--- a/tests/prism/overlay/test_controller.py
+++ b/tests/prism/overlay/test_controller.py
@@ -115,16 +115,16 @@ def test_real_overlay_controller_get_playerdata() -> None:
     assert playerdata is None
 
     error = APIKeyError()
-    assert not controller.api_key_invalid
+    assert not controller.antisniper_api_key_invalid
     _, playerdata = controller.get_playerdata("uuid")
     assert playerdata is ERROR_DURING_PROCESSING
-    assert controller.api_key_invalid
+    assert controller.antisniper_api_key_invalid
 
     error = APIThrottleError()
-    assert not controller.api_key_throttled
+    assert not controller.antisniper_api_key_throttled
     _, playerdata = controller.get_playerdata("uuid")
     assert playerdata is ERROR_DURING_PROCESSING
-    assert controller.api_key_throttled
+    assert controller.antisniper_api_key_throttled
 
     error = MissingLocalIssuerSSLError()
     assert not controller.missing_local_issuer_certificate
@@ -138,8 +138,8 @@ def test_real_overlay_controller_get_playerdata() -> None:
     assert playerdata is returned_playerdata
     assert dataReceivedAtMs == 1234567890123456789 // 1_000_000
 
-    assert not controller.api_key_invalid
-    assert not controller.api_key_throttled
+    assert not controller.antisniper_api_key_invalid
+    assert not controller.antisniper_api_key_throttled
     assert not controller.missing_local_issuer_certificate
 
 

--- a/tests/prism/overlay/test_controller.py
+++ b/tests/prism/overlay/test_controller.py
@@ -8,6 +8,7 @@ from prism.ratelimiting import RateLimiter
 from prism.ssl_errors import MissingLocalIssuerSSLError
 from tests.prism.overlay.utils import (
     MockedAccountProvider,
+    MockedPlayerProvider,
     assert_not_called,
     create_controller,
     make_settings,
@@ -106,7 +107,9 @@ def test_real_overlay_controller_get_playerdata() -> None:
             use_antisniper_api=True,
             user_id="1234",
         ),
-        get_playerdata=mock_get_playerdata,
+        player_provider=MockedPlayerProvider(
+            get_playerdata_for_uuid=mock_get_playerdata
+        ),
         get_time_ns=mock_get_time_ns,
     )
     error = APIError()
@@ -181,7 +184,9 @@ def test_real_overlay_controller_get_playerdata_dependency_injection() -> None:
 
     controller = create_controller(
         settings=make_settings(user_id="test-user-id"),
-        get_playerdata=custom_get_playerdata,
+        player_provider=MockedPlayerProvider(
+            get_playerdata_for_uuid=custom_get_playerdata
+        ),
         get_time_ns=custom_get_time_ns,
     )
 
@@ -271,7 +276,9 @@ def test_real_overlay_controller_get_time_ns_dependency_injection() -> None:
 
     controller = create_controller(
         settings=make_settings(user_id="test-user-id"),
-        get_playerdata=custom_get_playerdata,
+        player_provider=MockedPlayerProvider(
+            get_playerdata_for_uuid=custom_get_playerdata
+        ),
         get_time_ns=custom_get_time_ns,
     )
 

--- a/tests/prism/overlay/test_controller.py
+++ b/tests/prism/overlay/test_controller.py
@@ -4,7 +4,6 @@ from prism.errors import APIError, APIKeyError, APIThrottleError, PlayerNotFound
 from prism.overlay.antisniper_api import AntiSniperAPIKeyHolder
 from prism.overlay.controller import ERROR_DURING_PROCESSING
 from prism.player import MISSING_WINSTREAKS, Winstreaks
-from prism.ratelimiting import RateLimiter
 from prism.ssl_errors import MissingLocalIssuerSSLError
 from tests.prism.overlay.utils import (
     MockedAccountProvider,
@@ -84,11 +83,7 @@ def test_real_overlay_controller_get_playerdata() -> None:
     error: Exception | None = None
     returned_playerdata: Mapping[str, object] = {}
 
-    def mock_get_playerdata(
-        uuid: str,
-        user_id: str,
-        api_limiter: RateLimiter,
-    ) -> Mapping[str, object]:
+    def mock_get_playerdata(uuid: str, user_id: str) -> Mapping[str, object]:
         assert uuid == "uuid"
         assert user_id == "1234"
 
@@ -168,11 +163,7 @@ def test_real_overlay_controller_get_playerdata_dependency_injection() -> None:
     """Test that OverlayController uses injected get_playerdata function"""
     custom_playerdata = {"custom": "data", "uuid": "test-uuid"}
 
-    def custom_get_playerdata(
-        uuid: str,
-        user_id: str,
-        api_limiter: RateLimiter,
-    ) -> Mapping[str, object]:
+    def custom_get_playerdata(uuid: str, user_id: str) -> Mapping[str, object]:
         assert uuid == "test-uuid"
         assert user_id == "test-user-id"
         return custom_playerdata
@@ -262,11 +253,7 @@ def test_real_overlay_controller_get_time_ns_dependency_injection() -> None:
 
     custom_playerdata = {"test": "data", "uuid": "test-uuid"}
 
-    def custom_get_playerdata(
-        uuid: str,
-        user_id: str,
-        api_limiter: RateLimiter,
-    ) -> Mapping[str, object]:
+    def custom_get_playerdata(uuid: str, user_id: str) -> Mapping[str, object]:
         assert uuid == "test-uuid"
         assert user_id == "test-user-id"
         return custom_playerdata

--- a/tests/prism/overlay/test_controller.py
+++ b/tests/prism/overlay/test_controller.py
@@ -87,7 +87,6 @@ def test_real_overlay_controller_get_playerdata() -> None:
     def mock_get_playerdata(
         uuid: str,
         user_id: str,
-        key_holder: AntiSniperAPIKeyHolder | None,
         api_limiter: RateLimiter,
     ) -> Mapping[str, object]:
         assert uuid == "uuid"
@@ -172,7 +171,6 @@ def test_real_overlay_controller_get_playerdata_dependency_injection() -> None:
     def custom_get_playerdata(
         uuid: str,
         user_id: str,
-        key_holder: AntiSniperAPIKeyHolder | None,
         api_limiter: RateLimiter,
     ) -> Mapping[str, object]:
         assert uuid == "test-uuid"
@@ -267,7 +265,6 @@ def test_real_overlay_controller_get_time_ns_dependency_injection() -> None:
     def custom_get_playerdata(
         uuid: str,
         user_id: str,
-        key_holder: AntiSniperAPIKeyHolder | None,
         api_limiter: RateLimiter,
     ) -> Mapping[str, object]:
         assert uuid == "test-uuid"

--- a/tests/prism/overlay/test_controller.py
+++ b/tests/prism/overlay/test_controller.py
@@ -17,29 +17,6 @@ from tests.prism.overlay.utils import (
 )
 
 
-def test_real_overlay_controller() -> None:
-    controller = create_controller(
-        settings=make_settings(
-            antisniper_api_key="antisniper_key",
-            use_antisniper_api=True,
-        ),
-    )
-
-    assert controller.antisniper_key_holder is not None
-    assert controller.antisniper_key_holder.key == "antisniper_key"
-
-
-def test_real_overlay_controller_no_antisniper_key() -> None:
-    controller = create_controller(
-        settings=make_settings(
-            antisniper_api_key=None,
-            use_antisniper_api=True,
-        ),
-    )
-
-    assert controller.antisniper_key_holder is None
-
-
 def test_real_overlay_controller_get_uuid() -> None:
     error: Exception | None = None
     returned_uuid: str = ""

--- a/tests/prism/overlay/test_controller.py
+++ b/tests/prism/overlay/test_controller.py
@@ -38,9 +38,9 @@ def test_real_overlay_controller_no_antisniper_key() -> None:
 
 def test_real_overlay_controller_get_uuid() -> None:
     error: Exception | None = None
-    returned_uuid: str | None = None
+    returned_uuid: str = ""
 
-    def get_uuid_mock(username: str) -> str | None:
+    def get_uuid_mock(username: str) -> str:
         assert username == "username"
         if error:
             raise error
@@ -59,6 +59,10 @@ def test_real_overlay_controller_get_uuid() -> None:
     error = APIError()
     uuid = controller.get_uuid("username")
     assert uuid is ERROR_DURING_PROCESSING
+
+    error = PlayerNotFoundError()
+    uuid = controller.get_uuid("username")
+    assert uuid is None
 
     error = MissingLocalIssuerSSLError()
     assert not controller.missing_local_issuer_certificate

--- a/tests/prism/overlay/test_controller.py
+++ b/tests/prism/overlay/test_controller.py
@@ -8,6 +8,7 @@ from prism.ssl_errors import MissingLocalIssuerSSLError
 from tests.prism.overlay.utils import (
     MockedAccountProvider,
     MockedPlayerProvider,
+    MockedWinstreakProvider,
     assert_not_called,
     create_controller,
     make_settings,
@@ -196,6 +197,7 @@ def test_real_overlay_controller_get_estimated_winstreaks_dependency_injection()
         uuid: str, key_holder: AntiSniperAPIKeyHolder
     ) -> tuple[Winstreaks, bool]:
         assert uuid == "test-uuid"
+        assert key_holder is not None
         assert key_holder.key == "test-api-key"
         return custom_winstreaks, custom_accurate
 
@@ -204,7 +206,9 @@ def test_real_overlay_controller_get_estimated_winstreaks_dependency_injection()
             antisniper_api_key="test-api-key",
             use_antisniper_api=True,
         ),
-        get_estimated_winstreaks=custom_get_estimated_winstreaks,
+        winstreak_provider=MockedWinstreakProvider(
+            get_estimated_winstreaks_for_uuid=custom_get_estimated_winstreaks,
+        ),
     )
 
     winstreaks, accurate = controller.get_estimated_winstreaks("test-uuid")
@@ -220,7 +224,9 @@ def test_real_overlay_controller_get_estimated_winstreaks_no_api() -> None:
             antisniper_api_key="test-api-key",
             use_antisniper_api=False,  # API is disabled
         ),
-        get_estimated_winstreaks=assert_not_called,
+        winstreak_provider=MockedWinstreakProvider(
+            get_estimated_winstreaks_for_uuid=assert_not_called,
+        ),
     )
 
     winstreaks, accurate = controller.get_estimated_winstreaks("test-uuid")
@@ -236,7 +242,9 @@ def test_real_overlay_controller_get_estimated_winstreaks_no_key() -> None:
             antisniper_api_key=None,  # No API key
             use_antisniper_api=True,
         ),
-        get_estimated_winstreaks=assert_not_called,
+        winstreak_provider=MockedWinstreakProvider(
+            get_estimated_winstreaks_for_uuid=assert_not_called,
+        ),
     )
 
     winstreaks, accurate = controller.get_estimated_winstreaks("test-uuid")

--- a/tests/prism/overlay/test_controller.py
+++ b/tests/prism/overlay/test_controller.py
@@ -7,6 +7,7 @@ from prism.player import MISSING_WINSTREAKS, Winstreaks
 from prism.ratelimiting import RateLimiter
 from prism.ssl_errors import MissingLocalIssuerSSLError
 from tests.prism.overlay.utils import (
+    MockedAccountProvider,
     assert_not_called,
     create_controller,
     make_settings,
@@ -53,7 +54,7 @@ def test_real_overlay_controller_get_uuid() -> None:
             use_antisniper_api=True,
             user_id="1234",
         ),
-        get_uuid=get_uuid_mock,
+        account_provider=MockedAccountProvider(get_uuid_for_username=get_uuid_mock),
     )
 
     error = APIError()
@@ -153,7 +154,9 @@ def test_real_overlay_controller_get_uuid_dependency_injection() -> None:
         assert username == "testuser"
         return custom_uuid
 
-    controller = create_controller(get_uuid=custom_get_uuid)
+    controller = create_controller(
+        account_provider=MockedAccountProvider(get_uuid_for_username=custom_get_uuid)
+    )
 
     result = controller.get_uuid("testuser")
     assert result == custom_uuid

--- a/tests/prism/overlay/test_get_stats.py
+++ b/tests/prism/overlay/test_get_stats.py
@@ -12,7 +12,11 @@ from prism.overlay.controller import OverlayController
 from prism.overlay.get_stats import denick, fetch_bedwars_stats, get_bedwars_stats
 from prism.overlay.nick_database import NickDatabase
 from prism.player import KnownPlayer, NickedPlayer, UnknownPlayer
-from tests.prism.overlay.utils import MockedAccountProvider, create_controller
+from tests.prism.overlay.utils import (
+    MockedAccountProvider,
+    MockedPlayerProvider,
+    create_controller,
+)
 
 # Player data for a player who has been on Hypixel, but has not played bedwars
 NEW_PLAYER_DATA: Mapping[str, object] = {"stats": {}}
@@ -69,7 +73,7 @@ def make_scenario_controller(*users: User) -> OverlayController:
 
     controller = create_controller(
         account_provider=MockedAccountProvider(get_uuid_for_username=get_uuid),
-        get_playerdata=get_playerdata,
+        player_provider=MockedPlayerProvider(get_playerdata_for_uuid=get_playerdata),
         get_time_ns=get_time_ns,
         nick_database=NickDatabase([nick_table]),
     )
@@ -316,7 +320,7 @@ def test_get_bedwars_stats_cache_genus(clear: bool) -> None:
 
     controller = create_controller(
         account_provider=MockedAccountProvider(get_uuid_for_username=get_uuid),
-        get_playerdata=get_playerdata,
+        player_provider=MockedPlayerProvider(get_playerdata_for_uuid=get_playerdata),
         get_time_ns=get_time_ns,
     )
 
@@ -361,7 +365,7 @@ def test_fetch_bedwars_stats_error_during_playerdata() -> None:
 
     controller = create_controller(
         account_provider=MockedAccountProvider(get_uuid_for_username=get_uuid),
-        get_playerdata=get_playerdata,
+        player_provider=MockedPlayerProvider(get_playerdata_for_uuid=get_playerdata),
         get_time_ns=get_time_ns,
     )
 

--- a/tests/prism/overlay/test_get_stats.py
+++ b/tests/prism/overlay/test_get_stats.py
@@ -2,7 +2,6 @@ import itertools
 import unittest.mock
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any
 
 import pytest
 
@@ -60,9 +59,7 @@ def make_scenario_controller(*users: User) -> OverlayController:
 
         return user.uuid
 
-    def get_playerdata(
-        uuid: str, user_id: str, api_limiter: Any
-    ) -> Mapping[str, object]:
+    def get_playerdata(uuid: str, user_id: str) -> Mapping[str, object]:
         user = uuid_table.get(uuid, None)
         if user is None or user.playerdata is None:
             raise PlayerNotFoundError("Player not found")
@@ -306,9 +303,7 @@ def test_get_bedwars_stats_cache_genus(clear: bool) -> None:
         assert username == my_username
         return my_uuid
 
-    def get_playerdata(
-        uuid: str, user_id: str, api_limiter: Any
-    ) -> Mapping[str, object]:
+    def get_playerdata(uuid: str, user_id: str) -> Mapping[str, object]:
         assert uuid == my_uuid
         if clear:
             # While we were getting the playerdata, someone else cleared the cache
@@ -355,9 +350,7 @@ def test_fetch_bedwars_stats_error_during_playerdata() -> None:
     def get_uuid(username: str) -> str:
         return "uuid"
 
-    def get_playerdata(
-        uuid: str, user_id: str, api_limiter: Any
-    ) -> Mapping[str, object]:
+    def get_playerdata(uuid: str, user_id: str) -> Mapping[str, object]:
         raise APIError("Test error")
 
     def get_time_ns() -> int:

--- a/tests/prism/overlay/test_get_stats.py
+++ b/tests/prism/overlay/test_get_stats.py
@@ -61,7 +61,7 @@ def make_scenario_controller(*users: User) -> OverlayController:
         return user.uuid
 
     def get_playerdata(
-        uuid: str, user_id: str, antisniper_key_holder: Any, api_limiter: Any
+        uuid: str, user_id: str, api_limiter: Any
     ) -> Mapping[str, object]:
         user = uuid_table.get(uuid, None)
         if user is None or user.playerdata is None:
@@ -307,7 +307,7 @@ def test_get_bedwars_stats_cache_genus(clear: bool) -> None:
         return my_uuid
 
     def get_playerdata(
-        uuid: str, user_id: str, antisniper_key_holder: Any, api_limiter: Any
+        uuid: str, user_id: str, api_limiter: Any
     ) -> Mapping[str, object]:
         assert uuid == my_uuid
         if clear:
@@ -356,7 +356,7 @@ def test_fetch_bedwars_stats_error_during_playerdata() -> None:
         return "uuid"
 
     def get_playerdata(
-        uuid: str, user_id: str, antisniper_key_holder: Any, api_limiter: Any
+        uuid: str, user_id: str, api_limiter: Any
     ) -> Mapping[str, object]:
         raise APIError("Test error")
 

--- a/tests/prism/overlay/test_get_stats.py
+++ b/tests/prism/overlay/test_get_stats.py
@@ -49,9 +49,12 @@ def make_scenario_controller(*users: User) -> OverlayController:
     uuid_table = {user.uuid: user for user in users}
     nick_table = {user.nick: user.uuid for user in users if user.nick is not None}
 
-    def get_uuid(username: str) -> str | None:
+    def get_uuid(username: str) -> str:
         user = username_table.get(username, None)
-        return user.uuid if user is not None else None
+        if user is None:
+            raise PlayerNotFoundError("Player not found")
+
+        return user.uuid
 
     def get_playerdata(
         uuid: str, user_id: str, antisniper_key_holder: Any, api_limiter: Any
@@ -295,7 +298,7 @@ def test_get_bedwars_stats_cache_genus(clear: bool) -> None:
         **NEW_PLAYER_DATA,
     }
 
-    def get_uuid(username: str) -> str | None:
+    def get_uuid(username: str) -> str:
         assert username == my_username
         return my_uuid
 
@@ -332,7 +335,7 @@ def test_get_bedwars_stats_cache_genus(clear: bool) -> None:
 
 
 def test_fetch_bedwars_stats_error_during_uuid() -> None:
-    def get_uuid(username: str) -> str | None:
+    def get_uuid(username: str) -> str:
         raise APIError("Test error")
 
     controller = create_controller(get_uuid=get_uuid)
@@ -341,7 +344,7 @@ def test_fetch_bedwars_stats_error_during_uuid() -> None:
 
 
 def test_fetch_bedwars_stats_error_during_playerdata() -> None:
-    def get_uuid(username: str) -> str | None:
+    def get_uuid(username: str) -> str:
         return "uuid"
 
     def get_playerdata(

--- a/tests/prism/overlay/test_get_stats.py
+++ b/tests/prism/overlay/test_get_stats.py
@@ -12,7 +12,7 @@ from prism.overlay.controller import OverlayController
 from prism.overlay.get_stats import denick, fetch_bedwars_stats, get_bedwars_stats
 from prism.overlay.nick_database import NickDatabase
 from prism.player import KnownPlayer, NickedPlayer, UnknownPlayer
-from tests.prism.overlay.utils import create_controller
+from tests.prism.overlay.utils import MockedAccountProvider, create_controller
 
 # Player data for a player who has been on Hypixel, but has not played bedwars
 NEW_PLAYER_DATA: Mapping[str, object] = {"stats": {}}
@@ -68,7 +68,7 @@ def make_scenario_controller(*users: User) -> OverlayController:
         return CURRENT_TIME_MS * 1_000_000
 
     controller = create_controller(
-        get_uuid=get_uuid,
+        account_provider=MockedAccountProvider(get_uuid_for_username=get_uuid),
         get_playerdata=get_playerdata,
         get_time_ns=get_time_ns,
         nick_database=NickDatabase([nick_table]),
@@ -315,7 +315,9 @@ def test_get_bedwars_stats_cache_genus(clear: bool) -> None:
         return 1234567 * 1_000_000
 
     controller = create_controller(
-        get_uuid=get_uuid, get_playerdata=get_playerdata, get_time_ns=get_time_ns
+        account_provider=MockedAccountProvider(get_uuid_for_username=get_uuid),
+        get_playerdata=get_playerdata,
+        get_time_ns=get_time_ns,
     )
 
     player = create_known_player(
@@ -338,7 +340,9 @@ def test_fetch_bedwars_stats_error_during_uuid() -> None:
     def get_uuid(username: str) -> str:
         raise APIError("Test error")
 
-    controller = create_controller(get_uuid=get_uuid)
+    controller = create_controller(
+        account_provider=MockedAccountProvider(get_uuid_for_username=get_uuid)
+    )
 
     assert fetch_bedwars_stats("someone", controller) == UnknownPlayer("someone")
 
@@ -356,7 +360,9 @@ def test_fetch_bedwars_stats_error_during_playerdata() -> None:
         return CURRENT_TIME_MS * 1_000_000
 
     controller = create_controller(
-        get_uuid=get_uuid, get_playerdata=get_playerdata, get_time_ns=get_time_ns
+        account_provider=MockedAccountProvider(get_uuid_for_username=get_uuid),
+        get_playerdata=get_playerdata,
+        get_time_ns=get_time_ns,
     )
 
     assert fetch_bedwars_stats("someone", controller) == UnknownPlayer("someone")

--- a/tests/prism/overlay/test_settings.py
+++ b/tests/prism/overlay/test_settings.py
@@ -431,7 +431,7 @@ def test_flush_settings_from_controller() -> None:
 
     controller = create_controller(settings=settings)
 
-    controller.store_settings()
+    controller.settings.flush_to_disk()
 
     # File properly stored
     assert (

--- a/tests/prism/overlay/utils.py
+++ b/tests/prism/overlay/utils.py
@@ -325,7 +325,7 @@ class MockedPlayerProvider:
     def __init__(
         self,
         get_playerdata_for_uuid: Callable[
-            [str, str, "AntiSniperAPIKeyHolder | None", RateLimiter],
+            [str, str, RateLimiter],
             Mapping[str, object],
         ],
     ) -> None:
@@ -335,12 +335,9 @@ class MockedPlayerProvider:
         self,
         uuid: str,
         user_id: str,
-        antisniper_key_holder: "AntiSniperAPIKeyHolder | None",
         limiter: RateLimiter,
     ) -> Mapping[str, object]:
-        return self._get_playerdata_for_uuid(
-            uuid, user_id, antisniper_key_holder, limiter
-        )
+        return self._get_playerdata_for_uuid(uuid, user_id, limiter)
 
 
 def create_controller(

--- a/tests/prism/overlay/utils.py
+++ b/tests/prism/overlay/utils.py
@@ -23,7 +23,6 @@ from prism.player import (
     UnknownPlayer,
     Winstreaks,
 )
-from prism.ratelimiting import RateLimiter
 
 if TYPE_CHECKING:  # pragma: no cover
     from prism.overlay.antisniper_api import AntiSniperAPIKeyHolder
@@ -325,19 +324,24 @@ class MockedPlayerProvider:
     def __init__(
         self,
         get_playerdata_for_uuid: Callable[
-            [str, str, RateLimiter],
+            [str, str],
             Mapping[str, object],
         ],
+        seconds_until_unblocked: float = 0.0,
     ) -> None:
         self._get_playerdata_for_uuid = get_playerdata_for_uuid
+        self._seconds_until_unblocked = seconds_until_unblocked
 
     def get_playerdata_for_uuid(
         self,
         uuid: str,
         user_id: str,
-        limiter: RateLimiter,
     ) -> Mapping[str, object]:
-        return self._get_playerdata_for_uuid(uuid, user_id, limiter)
+        return self._get_playerdata_for_uuid(uuid, user_id)
+
+    @property
+    def seconds_until_unblocked(self) -> float:
+        return self._seconds_until_unblocked
 
 
 def create_controller(

--- a/tests/prism/overlay/utils.py
+++ b/tests/prism/overlay/utils.py
@@ -326,7 +326,7 @@ def create_controller(
     update_presence_event_set: bool = False,
     player_cache: PlayerCache | None = None,
     nick_database: NickDatabase | None = None,
-    get_uuid: Callable[[str], str | None] = assert_not_called,
+    get_uuid: Callable[[str], str] = assert_not_called,
     get_playerdata: Callable[
         [str, str, "AntiSniperAPIKeyHolder | None", RateLimiter], Mapping[str, object]
     ] = assert_not_called,

--- a/tests/prism/overlay/utils.py
+++ b/tests/prism/overlay/utils.py
@@ -1,7 +1,7 @@
 import io
 from collections.abc import Callable, Mapping, Set
 from pathlib import Path, PurePath
-from typing import TYPE_CHECKING, Any, Literal, TextIO, cast, overload
+from typing import Any, Literal, TextIO, cast, overload
 
 from prism.overlay.controller import (
     AccountProvider,
@@ -28,9 +28,6 @@ from prism.player import (
     UnknownPlayer,
     Winstreaks,
 )
-
-if TYPE_CHECKING:  # pragma: no cover
-    from prism.overlay.antisniper_api import AntiSniperAPIKeyHolder
 
 # Username set by default in create_state
 OWN_USERNAME = "OwnUsername"
@@ -353,16 +350,22 @@ class MockedWinstreakProvider:
     def __init__(
         self,
         get_estimated_winstreaks_for_uuid: Callable[
-            [str, "AntiSniperAPIKeyHolder"],
+            [str, str],
             tuple[Winstreaks, bool],
         ],
+        seconds_until_unblocked: float = 0.0,
     ) -> None:
         self._get_estimated_winstreaks_for_uuid = get_estimated_winstreaks_for_uuid
+        self._seconds_until_unblocked = seconds_until_unblocked
 
     def get_estimated_winstreaks_for_uuid(
-        self, uuid: str, *, antisniper_key_holder: "AntiSniperAPIKeyHolder"
+        self, uuid: str, *, antisniper_api_key: str
     ) -> tuple[Winstreaks, bool]:
-        return self._get_estimated_winstreaks_for_uuid(uuid, antisniper_key_holder)
+        return self._get_estimated_winstreaks_for_uuid(uuid, antisniper_api_key)
+
+    @property
+    def seconds_until_unblocked(self) -> float:
+        return self._seconds_until_unblocked
 
 
 def create_controller(

--- a/tests/prism/overlay/utils.py
+++ b/tests/prism/overlay/utils.py
@@ -372,8 +372,8 @@ def create_controller(
     state: OverlayState | None = None,
     settings: Settings | None = None,
     wants_shown: bool | None = None,
-    api_key_invalid: bool = False,
-    api_key_throttled: bool = False,
+    antisniper_api_key_invalid: bool = False,
+    antisniper_api_key_throttled: bool = False,
     missing_local_issuer_certificate: bool = False,
     ready: bool = True,
     autowho_event_set: bool = False,
@@ -397,8 +397,8 @@ def create_controller(
     )
 
     controller.wants_shown = wants_shown
-    controller.api_key_invalid = api_key_invalid
-    controller.api_key_throttled = api_key_throttled
+    controller.antisniper_api_key_invalid = antisniper_api_key_invalid
+    controller.antisniper_api_key_throttled = antisniper_api_key_throttled
     controller.missing_local_issuer_certificate = missing_local_issuer_certificate
     controller.ready = ready
 
@@ -418,8 +418,13 @@ def create_controller(
 def assert_controllers_equal(
     controller1: OverlayController, controller2: OverlayController, /
 ) -> None:
-    assert controller1.api_key_invalid == controller2.api_key_invalid
-    assert controller1.api_key_throttled == controller2.api_key_throttled
+    assert (
+        controller1.antisniper_api_key_invalid == controller2.antisniper_api_key_invalid
+    )
+    assert (
+        controller1.antisniper_api_key_throttled
+        == controller2.antisniper_api_key_throttled
+    )
     assert (
         controller1.missing_local_issuer_certificate
         == controller2.missing_local_issuer_certificate

--- a/tests/prism/test_mojang.py
+++ b/tests/prism/test_mojang.py
@@ -1,38 +1,4 @@
-import pytest
-
-from prism.mojang import MojangAccountProvider, compare_uuids
-
-
-@pytest.mark.parametrize(
-    "uuid_1, uuid_2, equal",
-    (
-        (
-            "4cea508d-954d-4261-8f07-4b7494ca1d02",
-            "4cea508d-954d-4261-8f07-4b7494ca1d02",
-            True,
-        ),
-        (
-            "4cea508d-954d-4261-8f07-4b7494ca1d02",
-            "4cea508d954d42618f074b7494ca1d02",
-            True,
-        ),
-        (
-            "4cea508d954d42618f074b7494ca1d02",
-            "4cea508d-954d-4261-8f07-4b7494ca1d02",
-            True,
-        ),
-        ("4cea508d954d42618f074b7494ca1d02", "4cea508d954d42618f074b7494ca1d02", True),
-        ("4cea508d954d42618f074", "4cea508d954d42618f074b7494ca1d02", False),
-        (
-            "abcabcabc4cea508d-954d-4261-8f07-4b7494ca1d02",
-            "4cea508d-954d-4261-8f07-4b7494ca1d02",
-            False,
-        ),
-        ("", "4cea508d-954d-4261-8f07-4b7494ca1d02", False),
-    ),
-)
-def test_compare_uuids(uuid_1: str, uuid_2: str, equal: bool) -> None:
-    assert compare_uuids(uuid_1, uuid_2) is equal
+from prism.mojang import MojangAccountProvider
 
 
 def test_make_provider() -> None:

--- a/tests/prism/test_mojang.py
+++ b/tests/prism/test_mojang.py
@@ -1,6 +1,6 @@
 import pytest
 
-from prism.mojang import compare_uuids
+from prism.mojang import MojangAccountProvider, compare_uuids
 
 
 @pytest.mark.parametrize(
@@ -33,3 +33,7 @@ from prism.mojang import compare_uuids
 )
 def test_compare_uuids(uuid_1: str, uuid_2: str, equal: bool) -> None:
     assert compare_uuids(uuid_1, uuid_2) is equal
+
+
+def test_make_provider() -> None:
+    MojangAccountProvider(retry_limit=3, initial_timeout=1.0)

--- a/tests/prism/test_uuid.py
+++ b/tests/prism/test_uuid.py
@@ -1,0 +1,35 @@
+import pytest
+
+from prism.uuid import compare_uuids
+
+
+@pytest.mark.parametrize(
+    "uuid_1, uuid_2, equal",
+    (
+        (
+            "4cea508d-954d-4261-8f07-4b7494ca1d02",
+            "4cea508d-954d-4261-8f07-4b7494ca1d02",
+            True,
+        ),
+        (
+            "4cea508d-954d-4261-8f07-4b7494ca1d02",
+            "4cea508d954d42618f074b7494ca1d02",
+            True,
+        ),
+        (
+            "4cea508d954d42618f074b7494ca1d02",
+            "4cea508d-954d-4261-8f07-4b7494ca1d02",
+            True,
+        ),
+        ("4cea508d954d42618f074b7494ca1d02", "4cea508d954d42618f074b7494ca1d02", True),
+        ("4cea508d954d42618f074", "4cea508d954d42618f074b7494ca1d02", False),
+        (
+            "abcabcabc4cea508d-954d-4261-8f07-4b7494ca1d02",
+            "4cea508d-954d-4261-8f07-4b7494ca1d02",
+            False,
+        ),
+        ("", "4cea508d-954d-4261-8f07-4b7494ca1d02", False),
+    ),
+)
+def test_compare_uuids(uuid_1: str, uuid_2: str, equal: bool) -> None:
+    assert compare_uuids(uuid_1, uuid_2) is equal


### PR DESCRIPTION
- **chore: Raise PlayerNotFound instead of returning None in get_uuid**
- **chore: Refactor get_uuid to AccountProvider**
- **chore: Move compare_uuids out of mojang.py**
- **chore: Refactor get_playerdata to PlayerProvider**
- **chore: Remove antisniper key holder as input to get playerdata**
- **chore: Give the player provider its own session**
- **chore: Move rate limiter into player provider**
- **chore: Remove controller.store_settings**
- **chore: Convert get estimated winstreaks into provider**
- **chore: Move rate limiter into antisniper winstreak provider**
- **chore: Remove no cover comment on get_estimated_winstreaks**
- **chore: Rename api key flags to antisniper api key**
- **fix: Ignore antisniper api key flags when autodenicking**
- **chore: Clarify docstring**
- **chore: Raise API key errors for 403 and 429 on winstreaks endpoint**
- **chore: Retry on global throttle from AntiSniper**
- **fix: Handle errors from winstreak provider**
- **chore: Raise error from get winstreaks**
- **chore: Update error messages**
- **chore: Don't update antisniper key flags in get playerdata**
- **chore: Remove controller.antisniper_key_holder**
- **chore: Add TODO for error handling**
