### PR TITLE
chore: Require support for arm64 and x86_64 on macOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,16 @@ dev = [
     "types-toml>=0.10.8.20240310",
 ]
 
+[tool.uv]
+# Require that the installed packages support both intel and apple silicon on macos.
+# NOTE: We actually want to enforce downloading universal2 wheels on macos when not
+#       using an sdist so that pyinstaller can correctly create a universal2 binary.
+#       This is not possible today. See e.g. https://github.com/astral-sh/uv/issues/13104
+required-environments = [
+  "sys_platform == 'darwin' and platform_machine == 'arm64'",
+  "sys_platform == 'darwin' and platform_machine == 'x86_64'",
+]
+
 [tool.black]
 exclude = '''
 /(

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.13"
+required-markers = [
+    "platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "platform_machine == 'x86_64' and sys_platform == 'darwin'",
+]
 
 [[package]]
 name = "altgraph"


### PR DESCRIPTION
Ideally we require the use of either a pure-python source distribution
or a universal2 build of all packages on macOS to ensure that
pyinstaller can produce a universal2 binary, but there does not seem to
be support for that currently.
