### PR TITLE
chore(dependabot): switch daily intervals to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
     cooldown:
       default-days: 7
     commit-message:
@@ -32,7 +32,7 @@ updates:
   - package-ecosystem: 'uv'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
     cooldown:
       default-days: 7
     commit-message:


### PR DESCRIPTION
## Summary
- Switch the `github-actions` and `uv` ecosystem schedules from `daily` to `weekly` to match GitHub's recommended cadence; with the existing 7-day `cooldown.default-days` a daily schedule mostly produces no-op checks.

## Test plan
- [ ] Confirm Dependabot accepts the file (no validation error in the GitHub UI for dependabot.yml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)