### PR TITLE
chore: Render update-severity notices in light green

### DIFF
--- a/src/prism/flashlight/notices.py
+++ b/src/prism/flashlight/notices.py
@@ -14,7 +14,7 @@ from prism.requests import make_prism_requests_session
 
 logger = logging.getLogger(__name__)
 
-Severity = Literal["info", "warning", "critical"]
+Severity = Literal["info", "update", "warning", "critical"]
 IncludeVersionUpdates = Literal["none", "minor", "all"]
 
 
@@ -123,7 +123,7 @@ def _parse_flashlight_notice(
         return None
 
     raw_severity = item.get("severity", None)
-    if raw_severity not in ("info", "warning", "critical"):
+    if raw_severity not in ("info", "update", "warning", "critical"):
         logger.error(f"Invalid flashlight notice severity: {raw_severity=}")
         return None
 

--- a/src/prism/overlay/output/overlay/run_overlay.py
+++ b/src/prism/overlay/output/overlay/run_overlay.py
@@ -111,6 +111,11 @@ def run_overlay(
         for notice in controller.flashlight_notices:
             if not notice.active:
                 continue
+            if (
+                notice.severity == "update"
+                and not controller.settings.check_for_updates
+            ):
+                continue
             if notice.severity == "info":
                 color = "light blue"
             elif notice.severity == "update":

--- a/src/prism/overlay/output/overlay/run_overlay.py
+++ b/src/prism/overlay/output/overlay/run_overlay.py
@@ -111,18 +111,18 @@ def run_overlay(
         for notice in controller.flashlight_notices:
             if not notice.active:
                 continue
+            if notice.severity == "info":
+                color = "light blue"
+            elif notice.severity == "update":
+                color = "light green"
+            elif notice.severity == "warning":
+                color = "orange"
+            else:
+                color = "red" if time.monotonic() % 2 > 1 else "white"
             info_cells.append(
                 InfoCellValue(
                     text=notice.message,
-                    color=(
-                        "light blue"
-                        if notice.severity == "info"
-                        else (
-                            "orange"
-                            if notice.severity == "warning"
-                            else ("red" if time.monotonic() % 2 > 1 else "white")
-                        )
-                    ),
+                    color=color,
                     url=notice.url,
                 )
             )

--- a/tests/prism/flashlight/test_notices.py
+++ b/tests/prism/flashlight/test_notices.py
@@ -94,6 +94,28 @@ def mock_get_time_seconds() -> float:
             ),
         ),
         (
+            # Real prism-notices response from flashlight for an outdated client
+            {
+                "notices": [
+                    {
+                        "message": "New update available! Click here to download.",
+                        "url": "https://github.com/Amund211/prism/releases/latest/",
+                        "severity": "update",
+                        "duration_seconds": 60,
+                    },
+                ],
+            },
+            (
+                FlashlightNotice(
+                    message="New update available! Click here to download.",
+                    severity="update",
+                    url="https://github.com/Amund211/prism/releases/latest/",
+                    created_at_seconds=CURRENT_TIME_SECONDS,
+                    duration_seconds=60,
+                ),
+            ),
+        ),
+        (
             {
                 "notices": [
                     {"message": "Valid info", "severity": "info"},


### PR DESCRIPTION
## Summary
- Accept the new `update` severity from flashlight `prism-notices` alongside `info`/`warning`/`critical`
- Render `update`-severity notices with the light green color that the old in-process GitHub update checker used, so the version-update banner looks the same as before

## Test plan
- [x] `pytest tests/prism/flashlight/`
- [x] `mypy` on changed files