### PR TITLE
chore: Add tests for appdirs

### DIFF
--- a/src/prism/overlay/directories.py
+++ b/src/prism/overlay/directories.py
@@ -1,16 +1,38 @@
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 
 from appdirs import AppDirs
 
-dirs = AppDirs(appname="prism_overlay")
 
-CACHE_DIR = Path(dirs.user_cache_dir)
-LOGDIR = Path(dirs.user_log_dir)
+@dataclass(frozen=True, slots=True)
+class PrismDirs:
+    cache_dir: Path
+    log_dir: Path
+    config_dir: Path
+    settings_path: Path
+    logfile_cache_path: Path
 
-CONFIG_DIR = Path(dirs.user_config_dir)
-DEFAULT_SETTINGS_PATH = CONFIG_DIR / "settings.toml"
-DEFAULT_LOGFILE_CACHE_PATH = CONFIG_DIR / "known_logfiles.toml"
+
+def get_dirs() -> PrismDirs:
+    app_dirs = AppDirs(appname="prism_overlay")
+    config_dir = Path(app_dirs.user_config_dir)
+    return PrismDirs(
+        cache_dir=Path(app_dirs.user_cache_dir),
+        log_dir=Path(app_dirs.user_log_dir),
+        config_dir=config_dir,
+        settings_path=config_dir / "settings.toml",
+        logfile_cache_path=config_dir / "known_logfiles.toml",
+    )
+
+
+dirs = get_dirs()
+
+CACHE_DIR = dirs.cache_dir
+LOGDIR = dirs.log_dir
+CONFIG_DIR = dirs.config_dir
+DEFAULT_SETTINGS_PATH = dirs.settings_path
+DEFAULT_LOGFILE_CACHE_PATH = dirs.logfile_cache_path
 
 logger = logging.getLogger(__name__)
 

--- a/tests/prism/overlay/test_directories.py
+++ b/tests/prism/overlay/test_directories.py
@@ -1,8 +1,64 @@
+import sys
 from pathlib import Path
 
 import pytest
 
-from prism.overlay.directories import ensure_directory, must_ensure_directory
+from prism.overlay.directories import (
+    PrismDirs,
+    ensure_directory,
+    get_dirs,
+    must_ensure_directory,
+)
+
+
+@pytest.fixture
+def clean_dirs_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin $HOME and clear XDG vars so get_dirs() returns deterministic paths."""
+    monkeypatch.setenv("HOME", "/home/test")
+    for var in (
+        "XDG_CACHE_HOME",
+        "XDG_CONFIG_HOME",
+        "XDG_STATE_HOME",
+        "XDG_DATA_HOME",
+        "XDG_RUNTIME_DIR",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux-specific paths")
+def test_linux_paths(clean_dirs_env: None) -> None:
+    config_dir = Path("/home/test/.config/prism_overlay")
+    assert get_dirs() == PrismDirs(
+        cache_dir=Path("/home/test/.cache/prism_overlay"),
+        log_dir=Path("/home/test/.cache/prism_overlay/log"),
+        config_dir=config_dir,
+        settings_path=config_dir / "settings.toml",
+        logfile_cache_path=config_dir / "known_logfiles.toml",
+    )
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS-specific paths")
+def test_macos_paths(clean_dirs_env: None) -> None:
+    config_dir = Path("/home/test/Library/Application Support/prism_overlay")
+    assert get_dirs() == PrismDirs(
+        cache_dir=Path("/home/test/Library/Caches/prism_overlay"),
+        log_dir=Path("/home/test/Library/Logs/prism_overlay"),
+        config_dir=config_dir,
+        settings_path=config_dir / "settings.toml",
+        logfile_cache_path=config_dir / "known_logfiles.toml",
+    )
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific paths")
+def test_windows_paths() -> None:
+    base = Path.home() / "AppData" / "Local" / "prism_overlay" / "prism_overlay"
+    assert get_dirs() == PrismDirs(
+        cache_dir=base / "Cache",
+        log_dir=base / "Logs",
+        config_dir=base,
+        settings_path=base / "settings.toml",
+        logfile_cache_path=base / "known_logfiles.toml",
+    )
 
 
 def test_ensure_directory(tmp_path: Path) -> None:


### PR DESCRIPTION
We'll be replacing this with platformdirs shortly, so it is nice to have
some assertions on the exact paths we produce so we don't get any
regressions.
