### PR TITLE
ci: Split testing workflow into parallel test and build jobs

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,23 +13,10 @@ jobs:
       matrix:
         include:
           - os: windows-latest
-            OS_NAME: windows
-            RESULT_EXTENSION: .exe
-            PYINSTALLER_ARGS: --hide-console=minimize-early --onefile
             INSTALL_CA_CERT: certutil.exe -addstore root local-ca.pem
           - os: ubuntu-latest
-            OS_NAME: linux
-            RESULT_EXTENSION: ""
-            PYINSTALLER_ARGS: --onefile
             INSTALL_CA_CERT: sudo cp local-ca.pem /usr/local/share/ca-certificates/local-ca.crt; sudo update-ca-certificates
           - os: macOS-15
-            OS_NAME: mac
-            # Upload the built .dmg app-installer
-            RESULT_EXTENSION: .dmg
-            # Target universal2 so that the built binary can run on both intel and apple silicon
-            # Pass --windowed to build a .app bundle
-            # Use --onedir instead of --onefile to avoid repeated security scans on startup
-            PYINSTALLER_ARGS: --target-architecture universal2 --windowed --onedir
             INSTALL_CA_CERT: sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain local-ca.pem
     defaults:
       run:
@@ -43,13 +30,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Install dependencies
-        run: |
-          uv sync
-
-          VERSION_STRING="$(uv run python -c 'from prism import VERSION_STRING; print(VERSION_STRING)')"
-          echo "VERSION_STRING=$VERSION_STRING" >> $GITHUB_ENV
-          echo "SIMPLE_NAME=prism-$VERSION_STRING" >> $GITHUB_ENV
-          echo "BUILD_RESULT_NAME=prism-$VERSION_STRING-${{ matrix.OS_NAME }}${{ matrix.RESULT_EXTENSION }}" >> $GITHUB_ENV
+        run: uv sync
 
       - name: Run typechecking
         run: |
@@ -61,7 +42,7 @@ jobs:
           uv run coverage report
 
       - name: tee | stderr
-        if: matrix.OS_NAME != 'windows'
+        if: runner.os != 'Windows'
         run: |
           echo 'TEE_STDERR=| tee /dev/stderr' >> $GITHUB_ENV
 
@@ -105,6 +86,48 @@ jobs:
           echo 'autowho = true' >> system_certs_settings.toml
 
           uv run prism_overlay.py --test-ssl --settings=system_certs_settings.toml --logfile=latest.log ${{ env.TEE_STDERR }} | grep '^Got response: Hello world' >/dev/null 2>&1
+
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            OS_NAME: windows
+            RESULT_EXTENSION: .exe
+            PYINSTALLER_ARGS: --hide-console=minimize-early --onefile
+          - os: ubuntu-latest
+            OS_NAME: linux
+            RESULT_EXTENSION: ""
+            PYINSTALLER_ARGS: --onefile
+          - os: macOS-15
+            OS_NAME: mac
+            # Upload the built .dmg app-installer
+            RESULT_EXTENSION: .dmg
+            # Target universal2 so that the built binary can run on both intel and apple silicon
+            # Pass --windowed to build a .app bundle
+            # Use --onedir instead of --onefile to avoid repeated security scans on startup
+            PYINSTALLER_ARGS: --target-architecture universal2 --windowed --onedir
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version-file: .python-version
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - name: Install dependencies
+        run: |
+          uv sync
+
+          VERSION_STRING="$(uv run python -c 'from prism import VERSION_STRING; print(VERSION_STRING)')"
+          echo "VERSION_STRING=$VERSION_STRING" >> $GITHUB_ENV
+          echo "SIMPLE_NAME=prism-$VERSION_STRING" >> $GITHUB_ENV
+          echo "BUILD_RESULT_NAME=prism-$VERSION_STRING-${{ matrix.OS_NAME }}${{ matrix.RESULT_EXTENSION }}" >> $GITHUB_ENV
 
       - name: Build binary with pyinstaller
         run: |


### PR DESCRIPTION
## Summary
- Splits the existing single `test` job per OS into two parallel jobs: `test` (typecheck + pytest + ssl-certs runtime check) and `build` (pyinstaller + DMG packaging + upload).
- Same 3-OS matrix shape for both jobs; pre-existing OS-gated steps (`tee | stderr` non-Windows, DMG packaging mac-only) stay matrix-gated.
- ssl-certs lives in `test` because it runs against the source via `uv run`, not the built binary.

## Why
The macOS critical path is dominated by DMG packaging (~60s) running serially after tests. Running test and build in parallel drops the macOS wall time from ~159s to ~109s (~31% saved). Linux/Windows also benefit by smaller amounts. Each job re-pays ~14s `uv sync` setup; that's the cost of parallelism, more than offset by macOS savings.

## Projected critical path (max of test/build per OS)
| OS | test | build | new | was | saved |
|---|---:|---:|---:|---:|---:|
| Linux | ~26s | ~52s | **52s** | 62s | 10s |
| Windows | ~42s | ~46s | **46s** | 79s | 33s |
| macOS | ~61s | **~109s** | **109s** | 159s | **~50s** |

Numbers from per-step durations on recent runs of `Python testing` (sampled 5 runs).

## Test plan
- [ ] Open the PR's Actions run; verify `test (windows-latest)`, `test (ubuntu-latest)`, `test (macOS-15)`, `build (windows-latest)`, `build (ubuntu-latest)`, `build (macOS-15)` all pass.
- [ ] Confirm artifact `prism-X.Y.Z-{linux,windows,mac}.{,.exe,.dmg}` is uploaded with the same naming as before.
- [ ] Compare critical-path wall time vs a recent main run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)