### PR TITLE
chore: Drop types-pillow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dev = [
     "pre-commit>=4.6.0",
     "pyinstaller>=6.20.0",
     "pytest>=9.0.3",
-    "types-pillow>=10.2.0.20240822",
     "types-pyinstaller>=6.20.0.20260503",
     "types-pynput>=1.8.1.20260408",
     "types-requests>=2.33.0.20260503",

--- a/uv.lock
+++ b/uv.lock
@@ -453,7 +453,6 @@ dev = [
     { name = "pre-commit" },
     { name = "pyinstaller" },
     { name = "pytest" },
-    { name = "types-pillow" },
     { name = "types-pyinstaller" },
     { name = "types-pynput" },
     { name = "types-requests" },
@@ -483,7 +482,6 @@ dev = [
     { name = "pre-commit", specifier = ">=4.6.0" },
     { name = "pyinstaller", specifier = ">=6.20.0" },
     { name = "pytest", specifier = ">=9.0.3" },
-    { name = "types-pillow", specifier = ">=10.2.0.20240822" },
     { name = "types-pyinstaller", specifier = ">=6.20.0.20260503" },
     { name = "types-pynput", specifier = ">=1.8.1.20260408" },
     { name = "types-requests", specifier = ">=2.33.0.20260503" },
@@ -795,15 +793,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
-]
-
-[[package]]
-name = "types-pillow"
-version = "10.2.0.20240822"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/4a/4495264dddaa600d65d68bcedb64dcccf9d9da61adff51f7d2ffd8e4c9ce/types-Pillow-10.2.0.20240822.tar.gz", hash = "sha256:559fb52a2ef991c326e4a0d20accb3bb63a7ba8d40eb493e0ecb0310ba52f0d3", size = 35389, upload-time = "2024-08-22T02:32:48.15Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/23/e81a5354859831fcf54d488d33b80ba6133ea84f874a9c0ec40a4881e133/types_Pillow-10.2.0.20240822-py3-none-any.whl", hash = "sha256:d9dab025aba07aeb12fd50a6799d4eac52a9603488eca09d7662543983f16c5d", size = 54354, upload-time = "2024-08-22T02:32:46.664Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Pillow ships inline type annotations since [10.3.0 (2024-04-01)](https://pillow.readthedocs.io/en/stable/releasenotes/10.3.0.html) via a `py.typed` marker, so the third-party `types-pillow` stub package is redundant.
- mypy reads types directly from Pillow now; verified by removing the dev dep and running the configured `mypy --strict .` — still passes (134 source files, no issues).

## Test plan
- [x] \`uv run mypy --strict .\` passes after removal