### PR TITLE
chore: Replace toml with tomllib + tomli-w

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "cachetools",
     "requests",
     "tendo>=0.3.0",
-    "toml",
+    "tomli-w",
     "truststore",
     "pynput",
     "pywin32; platform_system=='Windows'",
@@ -46,7 +46,6 @@ dev = [
     "types-pyinstaller>=6.20.0.20260503",
     "types-pynput>=1.8.1.20260408",
     "types-requests>=2.33.0.20260503",
-    "types-toml>=0.10.8.20260408",
 ]
 
 [tool.uv]

--- a/src/prism/overlay/settings.py
+++ b/src/prism/overlay/settings.py
@@ -1,11 +1,12 @@
 import logging
 import threading
+import tomllib
 import uuid
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from typing import Self, TextIO, TypedDict, TypeVar
 
-import toml
+import tomli_w
 
 from prism import VERSION_STRING
 from prism.overlay.keybinds import (
@@ -231,10 +232,21 @@ class Settings:
         self.greatest_version = new_settings["greatest_version"]
 
     def flush_to_disk(self) -> None:
-        # toml.load(path) uses encoding='utf-8'
+        # TOML has no null type, so recursively omit keys with None values;
+        # the readers handle missing keys (e.g. SpecialKeyDict.vk, optional
+        # api keys) by falling back to defaults.
         with self.write_settings_file_utf8() as f:
-            toml.dump(self.to_dict(), f)
+            f.write(tomli_w.dumps(_drop_none(self.to_dict())))
         logger.info(f"Wrote settings to disk: {self}")
+
+
+def _drop_none(data: Mapping[str, object]) -> dict[str, object]:
+    """Recursively drop keys whose value is None (TOML has no null type)."""
+    return {
+        k: _drop_none(v) if isinstance(v, Mapping) else v
+        for k, v in data.items()
+        if v is not None
+    }
 
 
 # Generic type for value_or_default
@@ -253,7 +265,7 @@ def api_key_is_valid(key: str) -> bool:
 
 def read_settings(read_file: Callable[[], TextIO]) -> Mapping[str, object]:
     with read_file() as f:
-        return toml.load(f)
+        return tomllib.loads(f.read())
 
 
 def get_boolean_setting(

--- a/src/prism/overlay/user_interaction/logfile_utils.py
+++ b/src/prism/overlay/user_interaction/logfile_utils.py
@@ -1,12 +1,13 @@
 import logging
 import platform
 import time
+import tomllib
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Self
 
-import toml
+import tomli_w
 
 logger = logging.getLogger(__name__)
 
@@ -337,7 +338,8 @@ def read_logfile_cache(logfile_cache_path: Path) -> tuple[LogfileCache, bool]:
     logfile_cache_updated = False
 
     try:
-        logfile_cache = toml.load(logfile_cache_path)
+        with logfile_cache_path.open("rb") as f:
+            logfile_cache = tomllib.load(f)
     except Exception:
         logger.exception("failed loading logfile cache")
         logfile_cache = {}
@@ -408,10 +410,12 @@ def write_logfile_cache(logfile_cache_path: Path, cache: LogfileCache) -> None:
         and 0 <= cache.last_used_index < len(known_logfiles)
         else None
     )
-    with logfile_cache_path.open("w") as cache_file:
-        toml.dump(
-            {"known_logfiles": known_logfiles, "last_used": last_used}, cache_file
-        )
+    # TOML has no null type, so only include last_used when present.
+    cache_data: dict[str, object] = {"known_logfiles": known_logfiles}
+    if last_used is not None:
+        cache_data["last_used"] = last_used
+    with logfile_cache_path.open("wb") as cache_file:
+        tomli_w.dump(cache_data, cache_file)
 
 
 def get_logfile(

--- a/tests/prism/overlay/user_interaction/test_logfile_utils.py
+++ b/tests/prism/overlay/user_interaction/test_logfile_utils.py
@@ -1,3 +1,4 @@
+import tomllib
 import unittest.mock
 from collections.abc import Mapping
 from dataclasses import replace
@@ -5,7 +6,7 @@ from pathlib import Path
 from typing import cast
 
 import pytest
-import toml
+import tomli_w
 
 from prism.overlay.user_interaction.logfile_utils import (
     ActiveLogfile,
@@ -245,8 +246,8 @@ def test_read_logfile_cache(
     monkeypatch.chdir(tmp_path)
     logfile_cache_path = tmp_path / "logfile_cache.toml"
 
-    with logfile_cache_path.open("w") as f:
-        toml.dump(cache_content, f)
+    with logfile_cache_path.open("wb") as f:
+        tomli_w.dump(cache_content, f)
 
     for filename in ("1", "2", "3"):
         with (tmp_path / filename).open("w") as f:
@@ -317,8 +318,8 @@ def test_write_logfile_cache(
     logfile_cache_path = tmp_path / "logfile_cache.toml"
 
     write_logfile_cache(logfile_cache_path, cache)
-    with logfile_cache_path.open("r") as f:
-        assert toml.load(f) == cache_content
+    with logfile_cache_path.open("rb") as f:
+        assert tomllib.load(f) == cache_content
 
 
 NOT_USED = cast(LogfileCache, None)

--- a/uv.lock
+++ b/uv.lock
@@ -438,7 +438,7 @@ dependencies = [
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "requests" },
     { name = "tendo" },
-    { name = "toml" },
+    { name = "tomli-w" },
     { name = "truststore" },
 ]
 
@@ -457,7 +457,6 @@ dev = [
     { name = "types-pyinstaller" },
     { name = "types-pynput" },
     { name = "types-requests" },
-    { name = "types-toml" },
 ]
 
 [package.metadata]
@@ -468,7 +467,7 @@ requires-dist = [
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "requests" },
     { name = "tendo", specifier = ">=0.3.0" },
-    { name = "toml" },
+    { name = "tomli-w" },
     { name = "truststore" },
 ]
 
@@ -487,7 +486,6 @@ dev = [
     { name = "types-pyinstaller", specifier = ">=6.20.0.20260503" },
     { name = "types-pynput", specifier = ">=1.8.1.20260408" },
     { name = "types-requests", specifier = ">=2.33.0.20260503" },
-    { name = "types-toml", specifier = ">=0.10.8.20260408" },
 ]
 
 [[package]]
@@ -780,12 +778,12 @@ wheels = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.10.2"
+name = "tomli-w"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]
@@ -834,15 +832,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/b8/57e94268c0d82ac3eaa2fc35aa8ca7bbc2542f726b67dcf90b0b00a3b14d/types_requests-2.33.0.20260503.tar.gz", hash = "sha256:9721b2d9dbee7131f2fb39f20f0ebb1999c18cef4b512c9a7932f3722de7c5f4", size = 23931, upload-time = "2026-05-03T05:20:08.882Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/82/959113a6351f3ca046cd0a8cd2cee071d7ea47473560557a01eeae9a6fe2/types_requests-2.33.0.20260503-py3-none-any.whl", hash = "sha256:02aaa7e3577a13471715bb1bddb693cc985ea514f754b503bf033e6a09a3e528", size = 20736, upload-time = "2026-05-03T05:20:07.858Z" },
-]
-
-[[package]]
-name = "types-toml"
-version = "0.10.8.20260408"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/71/9b/887564a51a84c96ba08b715570e546f0ea793df6372b736bfbc596ca5536/types_toml-0.10.8.20260408.tar.gz", hash = "sha256:6b30b031235565a12febb1388900b129f1adeabfcfa594da46d0372b2ac107ad", size = 9341, upload-time = "2026-04-08T04:27:54.394Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/f1/942d95ba026779bc6e3064f8b094216588dc3276cc328cf8e03a0541918d/types_toml-0.10.8.20260408-py3-none-any.whl", hash = "sha256:e958d4c660385e548705a298f17dc162baf44c8b6d6aff79aeefe75f4f77ac87", size = 9677, upload-time = "2026-04-08T04:27:53.526Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- The `uiri/toml` package has had no PyPI release since November 2020 and predates the TOML 1.0 specification.
- Switch reads to the stdlib `tomllib` (available since 3.11; we require 3.14) and writes to `tomli-w`. This matches the pattern used by pip, setuptools, build, and hatch.
- Drop `types-toml` from dev deps (no longer needed; `tomllib` is in typeshed, `tomli-w` ships its own stubs).

## Behavioural note: None handling
`tomli-w` strictly follows the TOML 1.0 spec, which has no null type. The previous `uiri/toml` implementation silently omitted `None` values. To preserve the existing read paths (which already fall back to defaults for missing keys, e.g. `SpecialKeyDict.vk`, the optional API keys, `logfile_cache.last_used`), a small recursive `_drop_none` helper is applied at the write boundary. No behaviour change is intended.

## Test plan
- [x] `uv run pytest` — 1340 passed, 2 skipped
- [x] `uv run coverage run && uv run coverage report` — 100%
- [x] `uv run mypy`, black, isort, flake8 (all via pre-commit) — all pass
- [ ] Manual: launch the overlay, verify settings file is read and written correctly (especially with a `vk: None` special-key keybind set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)