### PR TITLE
fix: Sleep in current player thread when no username is known

### DIFF
--- a/src/prism/overlay/current_player.py
+++ b/src/prism/overlay/current_player.py
@@ -49,6 +49,11 @@ class CurrentPlayerThread(threading.Thread):
         self.username = result.username
 
         if self.username is None:
+            # We don't have a username yet (e.g. the log parser hasn't seen the
+            # client's "Setting user" line). Sleep before returning so run()'s
+            # `while True` loop doesn't busy-wait and pin a CPU core while we wait
+            # for one to appear.
+            self.sleep(self.timeout)
             return
 
         if result.name_changed:

--- a/tests/prism/overlay/test_current_player.py
+++ b/tests/prism/overlay/test_current_player.py
@@ -344,6 +344,81 @@ def test_idle_known_username_waits_on_game_ended_event() -> None:
     assert wait_calls == [15, 15]
 
 
+def test_name_change_then_same_name_does_not_busy_loop() -> None:
+    """
+    A name change must advance state so it isn't re-entered forever.
+
+    The name-changed path produces no sleep when get_player hits a warm cache. It
+    avoids busy-looping only because `self.username` is updated to the new name, so
+    the next iteration is no longer name_changed and falls through to the blocking
+    idle path. This guards that guarantee: if the username assignment were ever
+    dropped, name_changed would stay True every iteration and (with a warm cache)
+    spin a CPU core with no sleep.
+    """
+    controller = create_controller(
+        state=create_state(
+            own_username="Main",
+        ),
+    )
+
+    # Pre-cache the player so get_player returns immediately - the worst case,
+    # since the name-changed path then performs no sleep of its own.
+    main = make_player("player", "Main", wins=10)
+    controller.player_cache.set_cached_player(
+        "Main", main, genus=controller.player_cache.current_genus
+    )
+
+    wait_calls: list[float | None] = []
+
+    def fake_wait(timeout: float | None = None) -> bool:
+        wait_calls.append(timeout)
+        return False  # No game ended
+
+    controller.game_ended_event.wait = fake_wait  # type: ignore[method-assign]
+
+    sleep_calls: list[float] = []
+
+    thread = CurrentPlayerThread(
+        controller=controller, sleep=sleep_calls.append, timeout=15
+    )
+
+    # Name change is handled once: username advances, an update is queued, and -
+    # because the cache is warm - it neither sleeps nor waits on the event.
+    thread.process_updates()
+
+    assert thread.username == "Main"
+    assert sleep_calls == []
+    assert wait_calls == []
+    assert_controllers_equal(
+        controller,
+        create_controller(
+            state=create_state(own_username="Main"),
+            current_player_updates=(main,),
+        ),
+        ignore_player_cache=True,
+    )
+
+    # Drain the queued update
+    controller.current_player_updates_queue.get_nowait()
+
+    # Holding the same name for a while must take the blocking idle path every time
+    # (no busy loop) and must not re-fire the name-changed handling.
+    for _ in range(3):
+        thread.process_updates()
+
+    assert sleep_calls == []
+    assert wait_calls == [15, 15, 15]
+    # No further updates queued - name_changed was not re-entered
+    assert_controllers_equal(
+        controller,
+        create_controller(
+            state=create_state(own_username="Main"),
+            current_player_updates=(),
+        ),
+        ignore_player_cache=True,
+    )
+
+
 def test_get_player_returns_none_on_name_changed() -> None:
     """Test that processing stops when get_player returns None on name change"""
     controller = create_controller(

--- a/tests/prism/overlay/test_current_player.py
+++ b/tests/prism/overlay/test_current_player.py
@@ -150,7 +150,15 @@ def test_regular_processing_order() -> None:
 
 
 def test_username_is_none() -> None:
-    """Test that processing stops early when username is None"""
+    """
+    Test that processing stops early when username is None
+
+    NOTE: It must still sleep before returning. run() calls process_updates() in a
+          tight `while True` loop, so a path that returns without blocking pins a CPU
+          core at 100%. This happens for the entire session whenever the log parser
+          never detects the client's username (e.g. an unrecognized "Setting user"
+          line, or the overlay tailing past it after a log rotation).
+    """
     controller = create_controller(
         state=create_state(
             own_username=None,  # No username set
@@ -162,9 +170,9 @@ def test_username_is_none() -> None:
     def sleep(duration: float) -> None:
         sleep_calls.append(duration)
 
-    thread = CurrentPlayerThread(controller=controller, sleep=sleep, timeout=0)
+    thread = CurrentPlayerThread(controller=controller, sleep=sleep, timeout=15)
 
-    # Process should do nothing when username is None
+    # Process should do nothing but sleep when username is None
     thread.process_updates()
 
     # No updates should be queued
@@ -179,12 +187,73 @@ def test_username_is_none() -> None:
         ignore_player_cache=True,
     )
 
-    # No sleep should have been called
-    assert sleep_calls == []
+    # We must sleep for the poll interval to avoid busy-looping in run()
+    assert sleep_calls == [15]
+
+
+def test_username_stays_none_does_not_busy_loop() -> None:
+    """
+    Repeatedly processing with no username must sleep on every iteration.
+
+    This is the primary prod busy-loop: run() spins process_updates() forever, and
+    when own_username is None every iteration must block, or one CPU core is pinned.
+    """
+    controller = create_controller(
+        state=create_state(
+            own_username=None,
+        ),
+    )
+
+    sleep_calls: list[float] = []
+
+    def sleep(duration: float) -> None:
+        sleep_calls.append(duration)
+
+    thread = CurrentPlayerThread(controller=controller, sleep=sleep, timeout=15)
+
+    for _ in range(5):
+        thread.process_updates()
+
+    # Every iteration must have slept - no busy loop
+    assert sleep_calls == [15] * 5
+
+
+def test_username_none_with_game_ended_set_still_sleeps() -> None:
+    """
+    A stale game_ended_event must not let the no-username path skip its sleep.
+
+    Guards against a future change adding event handling to the no-username path
+    that could return early (without blocking) when the event happens to be set.
+    """
+    controller = create_controller(
+        state=create_state(
+            own_username=None,
+        ),
+    )
+
+    # Stale event set while we still have no username
+    controller.game_ended_event.set()
+
+    sleep_calls: list[float] = []
+
+    def sleep(duration: float) -> None:
+        sleep_calls.append(duration)
+
+    thread = CurrentPlayerThread(controller=controller, sleep=sleep, timeout=15)
+
+    thread.process_updates()
+    thread.process_updates()
+
+    assert sleep_calls == [15, 15]
 
 
 def test_username_change_to_none() -> None:
-    """Test that username change from a value to None is handled"""
+    """
+    Test that username change from a value to None is handled
+
+    After the username clears, subsequent iterations converge on the stable
+    no-username state, which must keep sleeping rather than busy-looping.
+    """
     controller = create_controller(
         state=create_state(
             own_username="Main",
@@ -201,7 +270,7 @@ def test_username_change_to_none() -> None:
             "Main", main, genus=controller.player_cache.current_genus
         )
 
-    thread = CurrentPlayerThread(controller=controller, sleep=sleep, timeout=0)
+    thread = CurrentPlayerThread(controller=controller, sleep=sleep, timeout=15)
 
     # Initial process should cause one update
     thread.process_updates()
@@ -220,8 +289,59 @@ def test_username_change_to_none() -> None:
     # Username should be updated to None
     assert thread.username is None
 
-    # No sleep should be called when username changes to None
-    assert sleep_calls == []
+    # The transition iteration must sleep to avoid busy-looping
+    assert sleep_calls == [15]
+
+    # Further iterations in the stable no-username state must keep sleeping
+    sleep_calls.clear()
+    thread.process_updates()
+    thread.process_updates()
+    assert sleep_calls == [15, 15]
+
+
+def test_idle_known_username_waits_on_game_ended_event() -> None:
+    """
+    The idle (known username, no game ended) path must not busy-loop either.
+
+    Unlike the no-username path, it is paced by blocking on game_ended_event.wait()
+    for the poll interval. This guards that pacing so a refactor can't drop it.
+    """
+    controller = create_controller(
+        state=create_state(
+            own_username="Main",
+        ),
+    )
+
+    main = make_player("player", "Main")
+    controller.player_cache.set_cached_player(
+        "Main", main, genus=controller.player_cache.current_genus
+    )
+
+    wait_calls: list[float | None] = []
+
+    def fake_wait(timeout: float | None = None) -> bool:
+        wait_calls.append(timeout)
+        return False  # No game ended
+
+    # Shadow the bound method on this Event instance
+    controller.game_ended_event.wait = fake_wait  # type: ignore[method-assign]
+
+    sleep_calls: list[float] = []
+
+    thread = CurrentPlayerThread(
+        controller=controller, sleep=sleep_calls.append, timeout=15
+    )
+
+    # First call establishes the username (name_changed path, no idle wait)
+    thread.process_updates()
+    assert thread.username == "Main"
+    assert wait_calls == []
+
+    # Subsequent idle calls must block on the event for the poll interval
+    thread.process_updates()
+    thread.process_updates()
+
+    assert wait_calls == [15, 15]
 
 
 def test_get_player_returns_none_on_name_changed() -> None:

--- a/tests/prism/overlay/test_current_player.py
+++ b/tests/prism/overlay/test_current_player.py
@@ -299,12 +299,17 @@ def test_username_change_to_none() -> None:
     assert sleep_calls == [15, 15]
 
 
-def test_idle_known_username_waits_on_game_ended_event() -> None:
+def test_no_op_fallthrough_relies_on_blocking_event_wait() -> None:
     """
-    The idle (known username, no game ended) path must not busy-loop either.
+    The no-op fallthrough (known username, no name change, no game ended) does no
+    work and no self.sleep of its own - it relies entirely on the blocking
+    game_ended_event.wait() for pacing. That bottom return is the only way to reach
+    the fallthrough, so the wait must have run.
 
-    Unlike the no-username path, it is paced by blocking on game_ended_event.wait()
-    for the poll interval. This guards that pacing so a refactor can't drop it.
+    Assert, against the real Event (wrapped, not stubbed), that each idle call
+    invokes wait() with the poll-interval timeout, that it returns False (no game)
+    yielding a genuine no-op, and that the branch never falls back to a busy-loop
+    self.sleep.
     """
     controller = create_controller(
         state=create_state(
@@ -317,31 +322,48 @@ def test_idle_known_username_waits_on_game_ended_event() -> None:
         "Main", main, genus=controller.player_cache.current_genus
     )
 
+    # Wrap (not replace) the real Event.wait: record the call AND block on it, so
+    # the real event is what provides the pacing. The event is never set, so each
+    # wait blocks for the (small) timeout and returns False.
+    real_wait = controller.game_ended_event.wait
     wait_calls: list[float | None] = []
 
-    def fake_wait(timeout: float | None = None) -> bool:
+    def spy_wait(timeout: float | None = None) -> bool:
         wait_calls.append(timeout)
-        return False  # No game ended
+        return real_wait(timeout=timeout)
 
-    # Shadow the bound method on this Event instance
-    controller.game_ended_event.wait = fake_wait  # type: ignore[method-assign]
+    controller.game_ended_event.wait = spy_wait  # type: ignore[method-assign]
 
     sleep_calls: list[float] = []
 
+    # Small real timeout so the genuine blocking wait stays fast
     thread = CurrentPlayerThread(
-        controller=controller, sleep=sleep_calls.append, timeout=15
+        controller=controller, sleep=sleep_calls.append, timeout=0.02
     )
 
-    # First call establishes the username (name_changed path, no idle wait)
+    # First call establishes the username (name_changed path - no idle wait)
     thread.process_updates()
     assert thread.username == "Main"
     assert wait_calls == []
+    controller.current_player_updates_queue.get_nowait()  # drain the establish update
 
-    # Subsequent idle calls must block on the event for the poll interval
+    # No-op fallthrough: blocks on the real event wait, returns False, does nothing
     thread.process_updates()
     thread.process_updates()
 
-    assert wait_calls == [15, 15]
+    # The real event wait was invoked with the poll interval on each idle call
+    assert wait_calls == [0.02, 0.02]
+    # Pacing comes only from the event wait - never a busy-loop self.sleep
+    assert sleep_calls == []
+    # Genuinely a no-op: no new updates produced
+    assert_controllers_equal(
+        controller,
+        create_controller(
+            state=create_state(own_username="Main"),
+            current_player_updates=(),
+        ),
+        ignore_player_cache=True,
+    )
 
 
 def test_name_change_then_same_name_does_not_busy_loop() -> None:


### PR DESCRIPTION
## Problem

A user reported low framerate in Minecraft on v1.11 that improves on v1.9. Investigating the diff between the tags, the window/compositor code (`overlay_window.py`) is unchanged, but `CurrentPlayerThread` is **new** in this range and contains a busy-loop.

`CurrentPlayerThread.run()` spins `process_updates()` in a bare `while True` loop with no pacing of its own — pacing is meant to happen *inside* `process_updates()`. The no-username path (`own_username is None`) returned at the early `return` **without blocking**:

```python
self.username = result.username
if self.username is None:
    return  # no sleep, no wait
```

`own_username` defaults to `None` and is only set when the log parser sees the client's "Setting user" line. Whenever that line isn't present/recognized (unrecognized client format, or the overlay tailing past it after a log rotation), `own_username` stays `None` and the thread busy-waits, pinning one CPU core for the entire session — degrading in-game framerate. This is a genuine v1.9 → v1.11 regression since the thread is new.

## Fix

Sleep for the poll interval before the early return so the loop can't spin.

## Tests (red-green TDD)

Added/updated busy-loop regression tests, all verified RED before the fix and GREEN after:

- `test_username_is_none` — single no-username call must sleep *(previously asserted `sleep_calls == []`, i.e. encoded the bug as correct)*
- `test_username_stays_none_does_not_busy_loop` — primary scenario: every iteration must sleep
- `test_username_none_with_game_ended_set_still_sleeps` — guards against a stale `game_ended_event` skipping the sleep
- `test_username_change_to_none` — username clears to `None`, then converges on the stable spin *(also previously asserted the buggy `sleep_calls == []`)*
- `test_idle_known_username_waits_on_game_ended_event` — green guard locking the idle path's `game_ended_event.wait()` pacing so a refactor can't turn it into a spin

Other paths already assert their sleeps and stay green (`get_player` timeout `[1]*60`, game-ended `sleep(5)`/`sleep(65)`, name-change `sleep(1)`).

Full overlay suite: 1125 passed, 2 skipped. mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)