### PR TITLE
Send X-Client-Type/X-Client-Version headers to flashlight

### DIFF
--- a/src/prism/flashlight/account.py
+++ b/src/prism/flashlight/account.py
@@ -6,6 +6,7 @@ import requests
 from requests.exceptions import RequestException
 
 from prism.errors import APIError, PlayerNotFoundError
+from prism.flashlight.headers import make_flashlight_client_headers
 from prism.flashlight.url import FLASHLIGHT_API_URL
 from prism.player import Account
 from prism.ratelimiting import RateLimiter
@@ -44,7 +45,12 @@ class FlashlightAccountProvider:
             # Uphold our prescribed rate-limits
             with self._limiter:
                 response = self._session.get(
-                    url, headers={"X-User-Id": user_id}, timeout=10
+                    url,
+                    headers={
+                        "X-User-Id": user_id,
+                        **make_flashlight_client_headers(),
+                    },
+                    timeout=10,
                 )
         except RequestException as e:
             raise ExecutionError(

--- a/src/prism/flashlight/headers.py
+++ b/src/prism/flashlight/headers.py
@@ -1,0 +1,18 @@
+from prism import VERSION_STRING
+
+# Client identification headers sent with every request to the flashlight
+# backend so requests/metrics/logs can be sliced by client type and version.
+#
+# NOTE: These headers must ONLY be sent to flashlight - never to Hypixel,
+#       Mojang, or any other third-party server. Do not add them to the shared
+#       requests session (which is also used for the Hypixel API); merge them
+#       into the per-request headers of flashlight calls instead.
+CLIENT_TYPE = "prism"
+
+
+def make_flashlight_client_headers() -> dict[str, str]:
+    """Return the client identification headers for requests to flashlight"""
+    return {
+        "X-Client-Type": CLIENT_TYPE,
+        "X-Client-Version": VERSION_STRING,
+    }

--- a/src/prism/flashlight/notices.py
+++ b/src/prism/flashlight/notices.py
@@ -9,6 +9,7 @@ import requests
 from requests.exceptions import RequestException
 
 from prism import VERSION_STRING
+from prism.flashlight.headers import make_flashlight_client_headers
 from prism.flashlight.url import FLASHLIGHT_API_URL
 from prism.requests import make_prism_requests_session
 
@@ -69,7 +70,12 @@ def _make_flashlight_notices_request(
 ) -> Any | None:  # pragma: nocover
     headers = {
         "X-User-Id": user_id,
+        # TODO: X-Prism-Version is now redundant with the X-Client-Version
+        # header from make_flashlight_client_headers() (which carries the same
+        # VERSION_STRING). Remove this once v1.12.0+ adoption is high enough
+        # that X-Client-Version covers prism.
         "X-Prism-Version": VERSION_STRING,
+        **make_flashlight_client_headers(),
     }
 
     try:

--- a/src/prism/flashlight/tags.py
+++ b/src/prism/flashlight/tags.py
@@ -6,6 +6,7 @@ import requests
 from requests.exceptions import RequestException
 
 from prism.errors import APIError, APIKeyError
+from prism.flashlight.headers import make_flashlight_client_headers
 from prism.flashlight.url import FLASHLIGHT_API_URL
 from prism.player import Tags, TagSeverity
 from prism.ratelimiting import RateLimiter
@@ -40,7 +41,7 @@ class FlashlightTagsProvider:
         last_try: bool,
         urchin_api_key: str | None,
     ) -> requests.Response:  # pragma: nocover
-        headers = {"X-User-Id": user_id}
+        headers = {"X-User-Id": user_id, **make_flashlight_client_headers()}
         if urchin_api_key:
             headers["X-Urchin-Api-Key"] = urchin_api_key
 

--- a/src/prism/strange.py
+++ b/src/prism/strange.py
@@ -7,6 +7,7 @@ import requests
 from requests.exceptions import RequestException
 
 from prism.errors import APIError, APIKeyError, APIThrottleError, PlayerNotFoundError
+from prism.flashlight.headers import make_flashlight_client_headers
 from prism.hypixel import create_known_player, get_playerdata_field
 from prism.player import KnownPlayer
 from prism.ratelimiting import RateLimiter
@@ -120,7 +121,13 @@ class StrangePlayerProvider:
         try:
             # Uphold our prescribed rate-limits
             with self._limiter:
-                response = self._session.get(url, headers={"X-User-Id": user_id})
+                response = self._session.get(
+                    url,
+                    headers={
+                        "X-User-Id": user_id,
+                        **make_flashlight_client_headers(),
+                    },
+                )
         except RequestException as e:
             raise ExecutionError(
                 "Request to AntiSniper API failed due to an unknown error"

--- a/tests/prism/flashlight/test_headers.py
+++ b/tests/prism/flashlight/test_headers.py
@@ -1,0 +1,16 @@
+from prism import VERSION_STRING
+from prism.flashlight.headers import make_flashlight_client_headers
+
+
+def test_make_flashlight_client_headers() -> None:
+    assert make_flashlight_client_headers() == {
+        "X-Client-Type": "prism",
+        "X-Client-Version": VERSION_STRING,
+    }
+
+
+def test_make_flashlight_client_headers_returns_fresh_dict() -> None:
+    # Callers merge and mutate the result, so it must not share state
+    first = make_flashlight_client_headers()
+    first["X-User-Id"] = "mutated"
+    assert "X-User-Id" not in make_flashlight_client_headers()


### PR DESCRIPTION
## Context

[flashlight#328](https://github.com/Amund211/flashlight/pull/328) moves client identification off the free-form `User-Agent` onto two dedicated, low-cardinality headers so requests/metrics/logs/Sentry can be sliced by client programmatically:

- `X-Client-Type` → `prism` / `rainbow` / `unknown` / `missing`
- `X-Client-Version` → an allowlisted version / `evergreen` / `unknown` / `missing`

This PR makes the prism client send those headers.

## What's here

- **New `flashlight/headers.py`** — `make_flashlight_client_headers()` returns `X-Client-Type: prism` and `X-Client-Version: VERSION_STRING`. `VERSION_STRING` (currently `v1.11.1-dev`) is on the server's allowlist, so it normalizes correctly today and will keep working when bumped to `v1.12.0`.
- Headers merged into the **per-request** headers of all four flashlight call sites: `account`, `tags`, `notices`, and `strange` (playerdata).

## Only to flashlight

The `requests.Session` is shared with the Hypixel API (`api.hypixel.net`) and antisniper, so the headers are **not** set on the session (unlike `User-Agent`). They're merged into each flashlight call's own headers instead, so no client-identifying info leaks to third-party servers.

## Verification

- `mypy` ✅
- `pytest` ✅ (new `test_headers.py` covers the values + fresh-dict-per-call)
- pre-commit (black/isort/flake8/coverage @ 100%) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)