### PR TITLE
chore: gitignore sandbox-injected files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,14 @@ venv/
 
 # Claude config
 /.claude/*
+
+# Sandbox-injected files (shell/editor configs mounted into the working tree)
+/.bash_profile
+/.bashrc
+/.gitconfig
+/.gitmodules
+/.profile
+/.ripgreprc
+/.vscode
+/.zprofile
+/.zshrc


### PR DESCRIPTION
The sandbox mounts shell/editor config files (and a `.vscode` char device) into the working tree, cluttering `git status`. Ignore them.

Mirrors the same change made in rainbow (`7a62277`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)