### PR TITLE
feat(auth): anonymous auth sessions on every flashlight request

### DIFF
--- a/src/prism/flashlight/account.py
+++ b/src/prism/flashlight/account.py
@@ -1,11 +1,14 @@
 import functools
 import logging
+from collections.abc import Mapping
 from json import JSONDecodeError
 
 import requests
 from requests.exceptions import RequestException
 
 from prism.errors import APIError, PlayerNotFoundError
+from prism.flashlight.auth.manager import AuthManager
+from prism.flashlight.auth.request import send_authenticated
 from prism.flashlight.headers import make_flashlight_client_headers
 from prism.flashlight.url import FLASHLIGHT_API_URL
 from prism.player import Account
@@ -21,12 +24,14 @@ class FlashlightAccountProvider:
         self,
         *,
         session: requests.Session,
+        auth: AuthManager,
         retry_limit: int,
         initial_timeout: float,
     ) -> None:
         self._retry_limit = retry_limit
         self._initial_timeout = initial_timeout
         self._session = session
+        self._auth = auth
         self._limiter = RateLimiter(limit=120, window=60)
 
     @property
@@ -41,17 +46,19 @@ class FlashlightAccountProvider:
         user_id: str,
         last_try: bool,
     ) -> requests.Response:  # pragma: nocover
-        try:
+        headers = {"X-User-Id": user_id, **make_flashlight_client_headers()}
+
+        def send(auth_headers: Mapping[str, str]) -> requests.Response:
             # Uphold our prescribed rate-limits
             with self._limiter:
-                response = self._session.get(
+                return self._session.get(
                     url,
-                    headers={
-                        "X-User-Id": user_id,
-                        **make_flashlight_client_headers(),
-                    },
+                    headers={**headers, **auth_headers},
                     timeout=10,
                 )
+
+        try:
+            response = send_authenticated(auth=self._auth, send=send)
         except RequestException as e:
             raise ExecutionError(
                 "Request to flashlight failed due to an unknown error"

--- a/src/prism/flashlight/auth/__init__.py
+++ b/src/prism/flashlight/auth/__init__.py
@@ -1,0 +1,21 @@
+"""
+Auth sessions for the flashlight API
+
+Flashlight issues short-lived opaque bearer sessions so that our per-user rate
+budget keys on an identity it has verified, rather than on the self-asserted
+`X-User-Id` header. Prism holds exactly one session for the whole process and
+sends it on every flashlight request.
+
+The pieces:
+
+- `session`         the `Session` value object and the login/refresh response parser
+- `proof_of_work`   the hash puzzle every anonymous login must solve
+- `endpoints`       the three HTTP calls (challenge, login, refresh)
+- `anonymous`       the anonymous tier's `LoginMethod`
+- `manager`         `AuthManager`, which owns the session and the auth thread
+- `request`         `send_authenticated`, used by every flashlight call site
+
+Only `anonymous` knows which tier we are on. Everything else works off a
+`Session` alone, so a second tier (Microsoft) is a second `LoginMethod` and
+nothing more.
+"""

--- a/src/prism/flashlight/auth/anonymous.py
+++ b/src/prism/flashlight/auth/anonymous.py
@@ -1,0 +1,48 @@
+import logging
+
+import requests
+
+from prism.flashlight.auth.endpoints import anonymous_login, request_challenge
+from prism.flashlight.auth.proof_of_work import solve_challenge
+from prism.flashlight.auth.session import Session
+
+logger = logging.getLogger(__name__)
+
+
+class AnonymousLogin:
+    """
+    The anonymous tier's `LoginMethod`: get a challenge, solve it, log in
+
+    Anonymous identity costs one round trip and no user interaction, so it is
+    what the overlay uses on first launch and by default. The proof-of-work is
+    what prices minting identities at all; the server picks the difficulty and
+    we just do the work.
+    """
+
+    tier = "anonymous"
+
+    def __init__(
+        self,
+        *,
+        requests_session: requests.Session,
+        user_id: str,
+    ) -> None:
+        self._requests_session = requests_session
+
+        # Read once, here, and used for both calls of the handshake. Flashlight
+        # compares the userId sent to /challenge with the one sent to /login byte
+        # for byte, so reading it from settings twice would risk a 403 that no
+        # retry can fix.
+        self._user_id = user_id
+
+    def log_in(self) -> Session:  # pragma: nocover
+        challenge = request_challenge(
+            requests_session=self._requests_session, user_id=self._user_id
+        )
+        solution = solve_challenge(challenge)
+        return anonymous_login(
+            requests_session=self._requests_session,
+            user_id=self._user_id,
+            challenge=challenge.challenge,
+            solution=solution,
+        )

--- a/src/prism/flashlight/auth/endpoints.py
+++ b/src/prism/flashlight/auth/endpoints.py
@@ -144,6 +144,20 @@ def refresh_session(
         # Either the too-soon throttle or the endpoint's IP rate limit. Both
         # leave the session untouched, and re-logging in is the wrong reaction
         # to both.
+        # TODO: The two causes are indistinguishable on the wire today, but they
+        #       do not mean the same thing, and we treat both as the server
+        #       vouching for our session: `_postpone` sets
+        #       `confirmed_session=True` and holds requests off for 5 minutes, so
+        #       every 401 in that window is handed back to the caller and
+        #       `tags.py` blames the Urchin API key - which latches
+        #       `urchin_api_key_invalid` permanently (once set, `urchin_api_key`
+        #       is passed as None, so the reset branch never runs). The IP limiter
+        #       runs before the handler and never looks at the bearer, so several
+        #       prism users behind one NAT/CGNAT IP can trip it while one of them
+        #       genuinely has a dead session: that user gets a permanent bogus
+        #       "Invalid Urchin API key" banner and stops sending a good key.
+        #       Only the too-soon throttle should confirm the session - needs the
+        #       server to tell the two apart.
         raise RefreshTooSoonError("Flashlight refused to refresh this session yet")
 
     if not response.ok:

--- a/src/prism/flashlight/auth/endpoints.py
+++ b/src/prism/flashlight/auth/endpoints.py
@@ -1,0 +1,152 @@
+import logging
+from json import JSONDecodeError
+from typing import Any
+
+import requests
+from requests.exceptions import RequestException
+
+from prism.flashlight.auth.errors import (
+    AuthError,
+    RefreshTooSoonError,
+    SessionExpiredError,
+)
+from prism.flashlight.auth.proof_of_work import Challenge, parse_challenge_response
+from prism.flashlight.auth.session import Session, parse_session_response
+from prism.flashlight.headers import make_flashlight_client_headers
+from prism.flashlight.url import FLASHLIGHT_API_URL
+
+logger = logging.getLogger(__name__)
+
+AUTH_TIMEOUT_SECONDS = 10
+
+# NOTE: Auth responses carry the session id, which is a bearer token. Never log
+#       a response body from these endpoints - status codes only.
+
+
+def _post_json(
+    requests_session: requests.Session,
+    *,
+    path: str,
+    body: dict[str, str],
+    headers: dict[str, str],
+) -> requests.Response:  # pragma: nocover
+    # NOTE: The flashlight API does **not** allow third-party access.
+    #       Do not send any requests to any endpoints without explicit permission.
+    #       Reach out on Discord for more information. https://discord.gg/k4FGUnEHYg
+    try:
+        return requests_session.post(
+            f"{FLASHLIGHT_API_URL}{path}",
+            # Sets Content-Type: application/json, which both anonymous
+            # endpoints require.
+            json=body,
+            headers=headers,
+            timeout=AUTH_TIMEOUT_SECONDS,
+        )
+    except RequestException as e:
+        raise AuthError(f"Request to {path} failed") from e
+
+
+def _parse_json(response: requests.Response, *, path: str) -> Any:  # pragma: nocover
+    try:
+        return response.json()
+    except JSONDecodeError as e:
+        raise AuthError(f"Failed parsing the response from {path}") from e
+
+
+def request_challenge(
+    *,
+    requests_session: requests.Session,
+    user_id: str,
+) -> Challenge:  # pragma: nocover
+    """Ask flashlight for a proof-of-work challenge to log in as `user_id`"""
+    path = "/v1/auth/anonymous/challenge"
+    response = _post_json(
+        requests_session,
+        path=path,
+        body={"userId": user_id},
+        headers={
+            # Sent so that the operator's user id blocklist also covers logins,
+            # and so the server can price the work by client type. The challenge
+            # is bound to the userId in the *body*, not to this header.
+            "X-User-Id": user_id,
+            **make_flashlight_client_headers(),
+        },
+    )
+
+    if not response.ok:
+        raise AuthError(
+            f"Failed getting a proof-of-work challenge, "
+            f"status code {response.status_code}"
+        )
+
+    return parse_challenge_response(_parse_json(response, path=path))
+
+
+def anonymous_login(
+    *,
+    requests_session: requests.Session,
+    user_id: str,
+    challenge: str,
+    solution: str,
+) -> Session:  # pragma: nocover
+    """
+    Exchange a solved challenge for a session
+
+    `user_id` must be byte for byte the value sent to `request_challenge` - the
+    server compares them, and a mismatch is a 403 no retry can fix.
+    """
+    path = "/v1/auth/anonymous/login"
+    response = _post_json(
+        requests_session,
+        path=path,
+        body={"userId": user_id, "challenge": challenge, "solution": solution},
+        headers={"X-User-Id": user_id, **make_flashlight_client_headers()},
+    )
+
+    if not response.ok:
+        # 403 is every verification failure at once - expired challenge, an IP
+        # that changed mid-handshake, insufficient work. They all want the same
+        # thing: a fresh challenge, after a backoff.
+        raise AuthError(f"Anonymous login failed, status code {response.status_code}")
+
+    return parse_session_response(_parse_json(response, path=path))
+
+
+def refresh_session(
+    session_id: str,
+    *,
+    requests_session: requests.Session,
+) -> Session:  # pragma: nocover
+    """
+    Extend the given session
+
+    Tier-agnostic: the server branches on the stored session, so this is the
+    same call whichever `LoginMethod` established it. The session id does not
+    rotate - the returned session carries the same id with later deadlines.
+    """
+    path = "/v1/auth/refresh"
+    response = _post_json(
+        requests_session,
+        path=path,
+        body={},
+        headers={
+            "Authorization": f"Bearer {session_id}",
+            **make_flashlight_client_headers(),
+        },
+    )
+
+    if response.status_code == 401:
+        raise SessionExpiredError(
+            "Flashlight will not refresh this session - it is finished"
+        )
+
+    if response.status_code == 429:
+        # Either the too-soon throttle or the endpoint's IP rate limit. Both
+        # leave the session untouched, and re-logging in is the wrong reaction
+        # to both.
+        raise RefreshTooSoonError("Flashlight refused to refresh this session yet")
+
+    if not response.ok:
+        raise AuthError(f"Session refresh failed, status code {response.status_code}")
+
+    return parse_session_response(_parse_json(response, path=path))

--- a/src/prism/flashlight/auth/errors.py
+++ b/src/prism/flashlight/auth/errors.py
@@ -1,0 +1,54 @@
+from prism.errors import APIError
+
+
+class AuthError(Exception):
+    """
+    Failed to establish or maintain a flashlight auth session
+
+    Always retryable. Every cause - a network failure, a 5xx, a 403 on the
+    handshake, a difficulty we refuse to work on - gets the same treatment,
+    because the client's move is the same for all of them: back off and try
+    again. Retrying a cause we cannot fix costs nothing and means a server-side
+    fix reaches every running overlay without a restart.
+    """
+
+
+class SessionExpiredError(AuthError):
+    """
+    The session cannot be refreshed - a full login is required
+
+    Flashlight answers 401 to /v1/auth/refresh when the session is unknown,
+    revoked, past its refresh window or past its absolute lifetime cap.
+    """
+
+
+class RefreshTooSoonError(AuthError):
+    """
+    Flashlight refused to refresh a session it considers too fresh (429)
+
+    The opposite of `SessionExpiredError`: the session is untouched and still
+    good, so the session must be kept and re-login must NOT happen. Folding
+    this into the 401 case would turn a throttle into a re-login stampede.
+    """
+
+
+class NoSessionError(APIError):
+    """
+    No auth session was available to make a flashlight request with
+
+    An `APIError` so that every existing call site handles it as the failed
+    request it is.
+    """
+
+
+class SessionRecoveryError(APIError):
+    """
+    A request got a 401 we cannot account for
+
+    The counterpart to handing a 401 back to the caller, which only happens when
+    the server has vouched for the session we hold. This says the opposite: we do
+    not know whose 401 it was, so a caller must not blame anything of its own for
+    it. `/v1/tags/{uuid}` is why that distinction exists - it answers 401 for an
+    invalid Urchin API key too, and wrongly latching that is sticky for the rest
+    of the process.
+    """

--- a/src/prism/flashlight/auth/manager.py
+++ b/src/prism/flashlight/auth/manager.py
@@ -1,0 +1,408 @@
+import logging
+import random
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Protocol
+
+from prism.flashlight.auth.errors import (
+    AuthError,
+    RefreshTooSoonError,
+    SessionExpiredError,
+)
+from prism.flashlight.auth.session import Session
+
+logger = logging.getLogger(__name__)
+
+# How long a flashlight request waits for a session before giving up.
+#
+# Every prism request carries a bearer, so this is also how long a request can
+# block when we have no session - including the denick dialog's, which runs on
+# the tkinter thread. It is far more than the two round trips a login needs, so
+# it only bites during an outage, and then it bounds the freeze to something a
+# user reads as "slow" rather than "hung".
+SESSION_WAIT_TIMEOUT_SECONDS = 10.0
+
+# Backoff for failed auth attempts. One curve for every cause, including the
+# ones we cannot fix (an algorithm we don't implement, a difficulty we refuse):
+# retrying those every few minutes costs nothing, and it means a server-side fix
+# recovers every running overlay on its own, with no restart.
+INITIAL_BACKOFF_SECONDS = 2.0
+MAX_BACKOFF_SECONDS = 300.0
+BACKOFF_MULTIPLIER = 2.0
+
+# How long to wait after the server says we refreshed too recently. No honest
+# client should ever see this - we refresh 55 minutes into a 1 hour session and
+# the server's floor is 30 minutes - so it is logged as the bug signal it is.
+# The session is untouched, so we keep using it.
+TOO_SOON_REFRESH_DELAY_SECONDS = 300.0
+
+
+class LoginMethod(Protocol):  # pragma: nocover
+    """
+    A way to establish a brand new session
+
+    The one tier-specific piece of the whole flow. Refreshing, scheduling,
+    waiting and the 401 path all work off a `Session` alone, so a second tier
+    (Microsoft) is a second implementation of this protocol and nothing else.
+    """
+
+    @property
+    def tier(self) -> str:
+        """The name of the tier this logs in to, for logging"""
+
+    def log_in(self) -> Session:
+        """Establish a new session, or raise `AuthError`"""
+
+
+# Extends the given session. Tier-agnostic - the server branches on the stored
+# session, not on the caller.
+RefreshSession = Callable[[str], Session]
+
+
+@dataclass(frozen=True, slots=True)
+class Recovery:
+    """
+    What can be done about a request that got a 401
+
+    The two fields are not redundant, and the difference is what keeps a valid
+    Urchin API key from being blamed for an auth problem. `/v1/tags/{uuid}`
+    answers 401 both for a bad key and for a session flashlight won't accept, so
+    a caller may only interpret a 401 as its own when we can say the session is
+    not the cause.
+    """
+
+    # A session to retry the request with, if we got one. Note refresh does not
+    # rotate the id, so this can carry the same token with later deadlines.
+    session: Session | None
+
+    # True only when the *server* told us the session is fine - it refused to
+    # replace one it considers too fresh. Then the 401 was about something else,
+    # and the caller is the one that can interpret it. False whenever we could not
+    # get a verdict, which includes a failed re-login and a timed-out wait: a
+    # caller must not blame anything of its own for a 401 we cannot account for.
+    session_confirmed: bool
+
+
+def _default_jitter() -> float:  # pragma: nocover
+    return random.uniform(0.75, 1.25)
+
+
+class AuthManager:
+    """
+    Owns prism's flashlight auth session
+
+    There is exactly one writer: the auth thread. Every login and every refresh
+    happens there, so we get single-flight structurally rather than by getting a
+    lock protocol right - which matters, because up to 16 stats threads share the
+    one bearer and they all see a 401 together when a session lapses.
+
+    Request threads only ever:
+
+    - read a snapshot, waiting for one to exist (`wait_for_session`)
+    - report that a snapshot got a 401 (`recover_from_unauthorized`)
+    - report that the server asked for a refresh (`note_refresh_hint`)
+
+    A `Session` is immutable and replaced wholesale, so "did anything change?" is
+    an identity comparison, which is what the 401 path uses to tell "your session
+    was renewed, try again" from "your session is fine, that 401 was about
+    something else".
+    """
+
+    def __init__(
+        self,
+        *,
+        login_method: LoginMethod,
+        refresh_session: RefreshSession,
+        monotonic: Callable[[], float] = time.monotonic,
+        jitter: Callable[[], float] = _default_jitter,
+    ) -> None:
+        self._login_method = login_method
+        self._refresh_session = refresh_session
+        self._monotonic = monotonic
+        self._jitter = jitter
+
+        self._condition = threading.Condition()
+
+        # Everything below is guarded by self._condition
+        self._session: Session | None = None
+        # Number of completed reconcile passes. Bumped exactly once per pass,
+        # whatever the outcome, so a waiter can tell "the auth thread has looked
+        # at this" from "nothing has happened yet".
+        self._passes = 0
+        # Monotonic deadline for the auth thread's next pass. Now, initially:
+        # we have no session and want one.
+        self._next_action_at = monotonic()
+        # Monotonic deadline before which a *request* may not ask for a pass.
+        # Only a failure moves it, and it is what stops 16 stats threads from
+        # each queueing another login attempt while auth is broken - the auth
+        # thread's own backoff would otherwise be bypassed on every 401.
+        self._retry_not_before = monotonic()
+        self._reconcile_requested = False
+        # Whether the last pass ended with the server vouching for the session we
+        # hold. Read by recover_from_unauthorized - see `Recovery`.
+        self._last_pass_confirmed_session = False
+        self._backoff_seconds = INITIAL_BACKOFF_SECONDS
+        self._consecutive_failures = 0
+        self._last_error: str | None = None
+
+    @property
+    def consecutive_failures(self) -> int:
+        """How many auth attempts have failed in a row"""
+        with self._condition:
+            return self._consecutive_failures
+
+    @property
+    def last_error(self) -> str | None:
+        """Why the last auth attempt failed, if it did"""
+        with self._condition:
+            return self._last_error
+
+    def start(self) -> None:  # pragma: nocover
+        """Start the auth thread, which establishes and maintains the session"""
+        threading.Thread(target=self._run, daemon=True, name="prism-auth").start()
+
+    def _run(self) -> None:  # pragma: nocover
+        while True:
+            try:
+                self.wait_for_work()
+                self.reconcile()
+            except Exception:
+                # Every flashlight request needs this thread, so it must not be
+                # possible for a bug in here to take the overlay down with it.
+                logger.exception("Unexpected error in the auth thread")
+                time.sleep(MAX_BACKOFF_SECONDS)
+
+    def wait_for_session(
+        self, timeout: float = SESSION_WAIT_TIMEOUT_SECONDS
+    ) -> Session | None:
+        """
+        Return the session to use, waiting up to `timeout` for one to exist
+
+        None means we have no session and could not get one in time. The auth
+        thread keeps trying in the background, so the next request may well
+        succeed.
+        """
+        deadline = self._monotonic() + timeout
+        with self._condition:
+            while self._session is None:
+                remaining = deadline - self._monotonic()
+                if remaining <= 0:
+                    return None
+                self._condition.wait(remaining)
+            return self._session
+
+    def recover_from_unauthorized(
+        self, observed: Session, timeout: float = SESSION_WAIT_TIMEOUT_SECONDS
+    ) -> "Recovery":
+        """
+        Handle a 401 for `observed` and report what can be done about it
+
+        See `Recovery`: either there is a session to retry with, or the server has
+        confirmed the one we hold is fine (so the 401 was about something else), or
+        we simply do not know.
+        """
+        deadline = self._monotonic() + timeout
+        with self._condition:
+            if observed is not self._session:
+                # Already replaced, by the auth thread's own timer or by another
+                # request's 401. Retry with what we have now - no server call.
+                # `None` here means it was replaced by nothing, i.e. discarded as
+                # dead, which is not a verdict on this 401.
+                return Recovery(session=self._session, session_confirmed=False)
+
+            if self._monotonic() < self._retry_not_before:
+                # Auth is failing, or the server has just refused to touch this
+                # session. Either way: don't queue an attempt per request, and
+                # don't make the caller wait for one.
+                return Recovery(
+                    session=None,
+                    session_confirmed=self._last_pass_confirmed_session,
+                )
+
+            target = self._passes + 1
+            self._reconcile_requested = True
+            self._condition.notify_all()
+
+            while self._passes < target:
+                remaining = deadline - self._monotonic()
+                if remaining <= 0:
+                    # Timed out waiting for the pass, so we have no verdict.
+                    return Recovery(session=None, session_confirmed=False)
+                self._condition.wait(remaining)
+
+            current = self._session
+            if current is not observed:
+                return Recovery(session=current, session_confirmed=False)
+            return Recovery(
+                session=None, session_confirmed=self._last_pass_confirmed_session
+            )
+
+    def note_refresh_hint(self, session: Session) -> None:
+        """
+        Act on the server's `X-Auth-Refresh` hint for `session`
+
+        A hint, never load-bearing: ignoring it stays correct and the reactive
+        401 path remains the guarantee. It is the one mechanism that lets
+        flashlight retune refresh timing for clients already in users' hands, so
+        it is worth obeying.
+        """
+        with self._condition:
+            if session is not self._session:
+                return
+            if self._monotonic() < self._retry_not_before:
+                # Same reason as in recover_from_unauthorized: a fan-out of
+                # responses must not out-vote the auth thread's backoff.
+                return
+            self._reconcile_requested = True
+            self._condition.notify_all()
+
+    def seconds_until_next_action(self) -> float:
+        """Return how long the auth thread should idle before its next pass"""
+        with self._condition:
+            if self._reconcile_requested:
+                return 0.0
+            return max(0.0, self._next_action_at - self._monotonic())
+
+    def wait_for_work(self) -> None:  # pragma: nocover
+        """Block until there is auth work to do"""
+        while True:
+            delay = self.seconds_until_next_action()
+            if delay <= 0:
+                return
+            with self._condition:
+                # Re-checked under the lock, since the delay above was computed
+                # without it. A stale delay only costs another loop, because
+                # every wait is bounded.
+                if self._reconcile_requested:
+                    return
+                self._condition.wait(delay)
+
+    def reconcile(self) -> None:
+        """
+        Bring the session up to date: log in, or refresh what we hold
+
+        Only the auth thread may call this - it is the single writer. Performs
+        the network work outside the lock, then publishes the outcome.
+        """
+        with self._condition:
+            session = self._session
+
+        try:
+            new_session = self._acquire(session)
+        except RefreshTooSoonError:
+            # The session is untouched and still good. Keeping it is the whole
+            # point: reacting to this by logging in again would turn the
+            # server's throttle into the re-login stampede it exists to prevent.
+            logger.warning(
+                "Flashlight refused to refresh our session as too recent. "
+                "Keeping it and trying again later."
+            )
+            self._postpone(TOO_SOON_REFRESH_DELAY_SECONDS)
+        except AuthError as e:
+            logger.warning("Failed establishing a flashlight auth session", exc_info=e)
+            self._fail(str(e))
+        except BaseException as e:
+            # A bug rather than an auth failure. Record it as a failure anyway,
+            # which publishes the pass and sets a retry deadline: without the
+            # deadline every request would go on paying the full session wait for
+            # a pass that cannot come while the auth thread sleeps this off.
+            logger.exception("Unexpected error while reconciling the auth session")
+            self._fail(f"unexpected error: {e!r}")
+            raise
+        else:
+            logger.info(
+                f"Established flashlight auth session "
+                f"(tier={new_session.tier}, can_refresh={new_session.can_refresh})"
+            )
+            self._succeed(new_session)
+
+    def _acquire(self, session: Session | None) -> Session:
+        """Return a usable session, refreshing the one we hold when we can"""
+        if session is None:
+            logger.info(f"Logging in to flashlight ({self._login_method.tier})")
+            return self._login_method.log_in()
+
+        if not session.can_refresh:
+            # The server said at issue time that refreshing this one again would
+            # be pointless, so don't spend a round trip finding that out.
+            logger.info("Session cannot be refreshed again - logging in")
+            return self._login_method.log_in()
+
+        try:
+            return self._refresh_session(session.session_id)
+        except SessionExpiredError:
+            logger.info("Session is no longer refreshable - logging in")
+            # Drop it before trying to log in, so that if the login also fails we
+            # aren't left handing a token we know is dead to every request.
+            # Validating an unknown bearer costs flashlight an uncached
+            # transaction, so hammering it with one is not a neutral act.
+            self._discard(session)
+            return self._login_method.log_in()
+
+    def _discard(self, session: Session) -> None:
+        """Stop handing out a session we know flashlight will not accept"""
+        with self._condition:
+            if session is self._session:
+                self._session = None
+
+    def _succeed(self, session: Session) -> None:
+        with self._condition:
+            self._session = session
+            # The one place a duration becomes a deadline, against the one clock
+            # this class owns.
+            self._next_action_at = self._monotonic() + session.refresh_in_seconds
+            self._retry_not_before = self._monotonic()
+            self._backoff_seconds = INITIAL_BACKOFF_SECONDS
+            self._consecutive_failures = 0
+            self._last_error = None
+            self._finish_pass(confirmed_session=False)
+
+    def _postpone(self, delay: float) -> None:
+        """
+        Nothing changed and nothing is wrong - come back later
+
+        **Never earlier than what was already scheduled.** The session we are
+        holding is good until its own refresh point, and a too-soon refusal says
+        nothing about that; moving the next attempt *forward* to `delay` would
+        walk into the same refusal again, and again, for as long as the server's
+        minimum interval has left to run.
+
+        Requests are held off for `delay` as well. The server has just told us it
+        will not touch this session, so asking again per 401 would only reproduce
+        the answer - and one of the two things that produce a 429 is the refresh
+        endpoint's own rate limit.
+        """
+        with self._condition:
+            retry_at = self._monotonic() + delay
+            self._next_action_at = max(retry_at, self._next_action_at)
+            self._retry_not_before = retry_at
+            self._finish_pass(confirmed_session=True)
+
+    def _fail(self, error: str) -> None:
+        with self._condition:
+            retry_at = self._monotonic() + self._backoff_seconds * self._jitter()
+            self._next_action_at = retry_at
+            self._retry_not_before = retry_at
+            self._backoff_seconds = min(
+                self._backoff_seconds * BACKOFF_MULTIPLIER, MAX_BACKOFF_SECONDS
+            )
+            self._consecutive_failures += 1
+            self._last_error = error
+            self._finish_pass(confirmed_session=False)
+
+    def _finish_pass(self, *, confirmed_session: bool) -> None:
+        """Publish the outcome of a reconcile pass. Caller holds the condition."""
+        # Cleared here, at the *end* of the pass. A request that reported a 401 or
+        # a refresh hint while this pass was in flight has already been served by
+        # it - the pass read the very session it is reporting about - so leaving
+        # the flag set would make the auth thread immediately reconcile again.
+        # Right after a successful refresh that second pass is a refresh the
+        # server refuses as too soon, and every bearer response carries
+        # `X-Auth-Refresh` from exactly the moment our own timer fires, so a
+        # lobby fan-out sets the flag every single time.
+        self._reconcile_requested = False
+        self._last_pass_confirmed_session = confirmed_session
+        self._passes += 1
+        self._condition.notify_all()

--- a/src/prism/flashlight/auth/manager.py
+++ b/src/prism/flashlight/auth/manager.py
@@ -172,6 +172,16 @@ class AuthManager:
                 # Every flashlight request needs this thread, so it must not be
                 # possible for a bug in here to take the overlay down with it.
                 logger.exception("Unexpected error in the auth thread")
+                # TODO: This sleep outlives the retry deadline that is supposed to
+                #       cover it. `reconcile`'s `except BaseException` calls `_fail`,
+                #       which sets `_retry_not_before` to the *current* backoff (2s
+                #       on the first failure), but we then sleep 300s. In between,
+                #       every 401'd request queues a pass and blocks the full
+                #       `SESSION_WAIT_TIMEOUT_SECONDS` waiting for a pass that
+                #       cannot come - including `set_nickname` -> `get_uuid` on the
+                #       tkinter thread, which is the frozen window that timeout
+                #       exists to bound. Sleep the current backoff instead, or have
+                #       `_fail` cover the sleep.
                 time.sleep(MAX_BACKOFF_SECONDS)
 
     def wait_for_session(
@@ -210,6 +220,20 @@ class AuthManager:
                 # request's 401. Retry with what we have now - no server call.
                 # `None` here means it was replaced by nothing, i.e. discarded as
                 # dead, which is not a verdict on this 401.
+                # TODO: Returning `None` here makes a fan-out of 401s fail outright
+                #       while the re-login it triggered is still in flight.
+                #       `self._session` is None for the whole login after `_discard`
+                #       (challenge + proof-of-work + login = two round trips), so
+                #       every other thread gets no session and no verdict and
+                #       raises `SessionRecoveryError` immediately. Concretely: a
+                #       laptop resumes from suspend - `time.monotonic()` does not
+                #       advance across suspend, so we still believe the session is
+                #       fresh while the server has expired it - the user opens a
+                #       lobby, up to 16 stats threads 401 together, and the whole
+                #       lobby renders as errors even though a valid session lands a
+                #       second later. `wait_for_session` would have waited; this
+                #       path does not. Fall through to the wait loop below when
+                #       `self._session is None`.
                 return Recovery(session=self._session, session_confirmed=False)
 
             if self._monotonic() < self._retry_not_before:

--- a/src/prism/flashlight/auth/proof_of_work.py
+++ b/src/prism/flashlight/auth/proof_of_work.py
@@ -1,0 +1,112 @@
+import hashlib
+import logging
+from dataclasses import dataclass
+
+from prism.flashlight.auth.errors import AuthError
+
+logger = logging.getLogger(__name__)
+
+# The only proof-of-work scheme we implement: find a solution such that
+# SHA-256(challenge + ":" + solution) has at least `difficulty` leading zero
+# bits.
+#
+# Anything else must be an error rather than a guess. That is what lets
+# flashlight introduce a v2 scheme without breaking overlays that are already
+# installed - they refuse the challenge, back off and keep refusing until the
+# server stops handing out a scheme they don't know.
+ALGORITHM_SHA256_LEADING_ZEROS = "sha256-leading-zeros-v1"
+
+# The hardest work we are willing to do, mirroring proofofwork.MaxDifficulty in
+# flashlight. A refusal threshold, not a setting: a server-side bug must not be
+# able to wedge the overlay in a hash loop.
+#
+# The *usable* band is well below this. A challenge expires 60 seconds after it
+# was minted, and the server checks that before it checks the work, so a
+# difficulty CPython cannot finish inside the window never converges at all.
+MAX_DIFFICULTY = 26
+
+# Difficulties at or above this are logged. Around a million hashes takes about
+# a second in CPython, and if we ever start paying that we want the record.
+NOTEWORTHY_DIFFICULTY = 20
+
+_DIGEST_BITS = 256
+
+
+@dataclass(frozen=True, slots=True)
+class Challenge:
+    """A proof-of-work challenge handed out by flashlight"""
+
+    # Opaque to us: signed and stateless server-side. Everything needed to solve
+    # it is in the other two fields.
+    challenge: str
+    algorithm: str
+    difficulty: int
+
+
+def parse_challenge_response(response_json: object) -> Challenge:
+    """Parse a proof-of-work challenge out of a challenge response"""
+    if not isinstance(response_json, dict):
+        raise AuthError(f"Invalid challenge response {response_json=}")
+
+    challenge = response_json.get("challenge", None)
+    if not isinstance(challenge, str) or not challenge:
+        raise AuthError(f"Invalid challenge in challenge response {challenge=}")
+
+    algorithm = response_json.get("algorithm", None)
+    if not isinstance(algorithm, str) or not algorithm:
+        raise AuthError(f"Invalid algorithm in challenge response {algorithm=}")
+
+    difficulty = response_json.get("difficulty", None)
+    if (
+        isinstance(difficulty, bool)
+        or not isinstance(difficulty, int)
+        or difficulty < 0
+    ):
+        raise AuthError(f"Invalid difficulty in challenge response {difficulty=}")
+
+    # `expiresInSeconds` is informational - we solve immediately, and the server
+    # is the one that decides whether we made it in time.
+    return Challenge(challenge=challenge, algorithm=algorithm, difficulty=difficulty)
+
+
+def leading_zero_bits(digest: bytes) -> int:
+    """Return the number of leading zero bits in the given digest"""
+    return _DIGEST_BITS - int.from_bytes(digest, "big").bit_length()
+
+
+def solve_challenge(challenge: Challenge) -> str:
+    """
+    Return a solution to the given proof-of-work challenge
+
+    Must only ever be called from the auth thread - never from the UI thread or
+    the game event path. At the difficulty the server asks for today this is a
+    single hash, but the whole point of the mechanism is that the server can
+    raise the number whenever it likes, without a client release.
+    """
+    if challenge.algorithm != ALGORITHM_SHA256_LEADING_ZEROS:
+        raise AuthError(
+            f"Unsupported proof-of-work algorithm {challenge.algorithm!r}. "
+            f"This client only implements {ALGORITHM_SHA256_LEADING_ZEROS!r}."
+        )
+
+    if challenge.difficulty > MAX_DIFFICULTY:
+        raise AuthError(
+            f"Refusing proof-of-work difficulty {challenge.difficulty} - "
+            f"this client works up to {MAX_DIFFICULTY}."
+        )
+
+    if challenge.difficulty >= NOTEWORTHY_DIFFICULTY:
+        logger.warning(f"Solving proof-of-work at difficulty {challenge.difficulty}")
+
+    prefix = f"{challenge.challenge}:".encode()
+
+    # A non-empty solution is required even at difficulty 0, where the empty
+    # string would be a perfectly valid proof - so we count from "0" rather than
+    # special-casing the easy path away.
+    counter = 0
+    while True:
+        solution = str(counter)
+        digest = hashlib.sha256(prefix + solution.encode()).digest()
+        if leading_zero_bits(digest) >= challenge.difficulty:
+            return solution
+        counter += 1

--- a/src/prism/flashlight/auth/request.py
+++ b/src/prism/flashlight/auth/request.py
@@ -1,0 +1,76 @@
+from collections.abc import Callable, Mapping
+
+import requests
+
+from prism.flashlight.auth.errors import NoSessionError, SessionRecoveryError
+from prism.flashlight.auth.manager import AuthManager
+from prism.flashlight.auth.session import Session
+
+# Set by flashlight on any response to a request that carried a valid bearer,
+# once that session is due for a refresh. A hint: we act on it by waking the auth
+# thread, and ignoring it would still be correct.
+REFRESH_HINT_HEADER = "X-Auth-Refresh"
+
+# Performs one HTTP request, merging in the given auth headers.
+SendRequest = Callable[[Mapping[str, str]], requests.Response]
+
+
+def bearer_headers(session: Session) -> dict[str, str]:
+    """Return the auth headers for the given session"""
+    return {"Authorization": f"Bearer {session.session_id}"}
+
+
+def send_authenticated(
+    *,
+    auth: AuthManager,
+    send: SendRequest,
+) -> requests.Response:
+    """
+    Send a flashlight request with our bearer, recovering once from a 401
+
+    `send` is called with the headers to merge into the request, and may be called
+    twice: prism holds one session for the whole process, so a lapsed session
+    means the first call 401s and the second carries a renewed bearer.
+
+    A 401 is only ever returned to the caller when the server has vouched for the
+    session we hold, which means the 401 was about something else — that is what
+    lets `/v1/tags/{uuid}` interpret its own 401 for an invalid Urchin API key. A
+    401 we cannot account for raises `SessionRecoveryError` instead, so no call
+    site can mistake an auth problem for one of its own.
+
+    NOTE: `send` must be safe to call twice. Every flashlight endpoint prism
+          calls is a read, so replaying one is harmless.
+    """
+    session = auth.wait_for_session()
+    if session is None:
+        raise NoSessionError("No flashlight auth session available")
+
+    response = send(bearer_headers(session))
+    if response.status_code != 401:
+        _note_refresh_hint(auth, session, response)
+        return response
+
+    recovery = auth.recover_from_unauthorized(session)
+    if recovery.session is None:
+        if recovery.session_confirmed:
+            # The server refuses to replace this session, so it is fine and the
+            # 401 belongs to the caller. Sending the same bearer again would only
+            # reproduce it.
+            return response
+        raise SessionRecoveryError(
+            "Got HTTP 401 from flashlight and could not renew the auth session"
+        )
+
+    response = send(bearer_headers(recovery.session))
+    _note_refresh_hint(auth, recovery.session, response)
+    return response
+
+
+def _note_refresh_hint(
+    auth: AuthManager, session: Session, response: requests.Response
+) -> None:
+    # Any non-empty value counts. The server sends "1" today and reserves room
+    # for a richer value later, and every value means the same thing to us:
+    # deal with this session now.
+    if response.headers.get(REFRESH_HINT_HEADER):
+        auth.note_refresh_hint(session)

--- a/src/prism/flashlight/auth/request.py
+++ b/src/prism/flashlight/auth/request.py
@@ -61,6 +61,16 @@ def send_authenticated(
             "Got HTTP 401 from flashlight and could not renew the auth session"
         )
 
+    # TODO: The retry's own 401 is returned with no verdict at all, which breaks
+    #       the invariant this docstring promises and `tags.py` relies on. Same for
+    #       the session `recover_from_unauthorized` hands back from the
+    #       already-replaced branch: nothing has vouched for it. Concretely, during
+    #       a flashlight rollout or with read-replica lag the first request 401s,
+    #       the refresh succeeds against the primary, and the retry hits a replica
+    #       that has not seen the new session and 401s again - `tags.py` then
+    #       blames the Urchin API key and latches `urchin_api_key_invalid` for the
+    #       rest of the process. A second 401 should raise `SessionRecoveryError`
+    #       rather than reach the caller.
     response = send(bearer_headers(recovery.session))
     _note_refresh_hint(auth, recovery.session, response)
     return response

--- a/src/prism/flashlight/auth/session.py
+++ b/src/prism/flashlight/auth/session.py
@@ -1,0 +1,79 @@
+import math
+from dataclasses import dataclass
+
+from prism.flashlight.auth.errors import AuthError
+
+# The shortest delay we will ever schedule a proactive refresh for.
+#
+# The server decides when we refresh (`refreshInSeconds`, ~55 minutes into a
+# 1 hour session today) and we just obey it - but a bug or a misconfiguration
+# there must not be able to turn the auth thread into a hash-and-HTTP loop.
+# Refreshing a session the server considers too fresh changes nothing and comes
+# back 429, so a zero delay would spin.
+MIN_REFRESH_DELAY_SECONDS = 60.0
+
+
+@dataclass(frozen=True, slots=True)
+class Session:
+    """
+    A flashlight auth session
+
+    Clock-free, and deliberately so: it holds the server's *duration*, never a
+    deadline. The server only ever sends durations, and `AuthManager` is the one
+    place that turns one into a deadline against its own monotonic clock — so
+    there is exactly one clock in the whole flow, and nothing in prism ever
+    compares wall-clock times. That is what makes NTP skew, a suspended laptop
+    and a user changing their clock all non-events.
+    """
+
+    session_id: str
+    tier: str
+
+    # False once the server knows another refresh would be pointless - it would
+    # be clamped to the session's absolute lifetime cap, or refused. The session
+    # we are holding is still fully usable; it is the *next* renewal that has to
+    # be a fresh login instead of a refresh.
+    can_refresh: bool
+
+    # How long from being issued until we should renew it - the server's
+    # `refreshInSeconds`, floored.
+    refresh_in_seconds: float
+
+
+def parse_session_response(response_json: object) -> Session:
+    """Parse a session out of a login or refresh response"""
+    if not isinstance(response_json, dict):
+        raise AuthError(f"Invalid session response {response_json=}")
+
+    session_id = response_json.get("sessionId", None)
+    if not isinstance(session_id, str) or not session_id:
+        raise AuthError(f"Invalid sessionId in session response {session_id=}")
+
+    tier = response_json.get("tier", None)
+    if not isinstance(tier, str) or not tier:
+        raise AuthError(f"Invalid tier in session response {tier=}")
+
+    can_refresh = response_json.get("canRefresh", None)
+    if not isinstance(can_refresh, bool):
+        raise AuthError(f"Invalid canRefresh in session response {can_refresh=}")
+
+    refresh_in_seconds = response_json.get("refreshInSeconds", None)
+    if (
+        isinstance(refresh_in_seconds, bool)
+        or not isinstance(refresh_in_seconds, (int, float))
+        or not math.isfinite(refresh_in_seconds)
+        or refresh_in_seconds < 0
+    ):
+        raise AuthError(
+            f"Invalid refreshInSeconds in session response {refresh_in_seconds=}"
+        )
+
+    # `expiresInSeconds` and `refreshUntilInSeconds` are informational only -
+    # `refreshInSeconds` is the one the client is meant to act on, so we don't
+    # store durations we would never read.
+    return Session(
+        session_id=session_id,
+        tier=tier,
+        can_refresh=can_refresh,
+        refresh_in_seconds=max(float(refresh_in_seconds), MIN_REFRESH_DELAY_SECONDS),
+    )

--- a/src/prism/flashlight/notices.py
+++ b/src/prism/flashlight/notices.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from json import JSONDecodeError
 from typing import Any, Literal
@@ -9,6 +9,9 @@ import requests
 from requests.exceptions import RequestException
 
 from prism import VERSION_STRING
+from prism.flashlight.auth.errors import NoSessionError
+from prism.flashlight.auth.manager import AuthManager
+from prism.flashlight.auth.request import send_authenticated
 from prism.flashlight.headers import make_flashlight_client_headers
 from prism.flashlight.url import FLASHLIGHT_API_URL
 from prism.requests import make_prism_requests_session
@@ -65,6 +68,7 @@ class FlashlightNotice:
 def _make_flashlight_notices_request(
     session: requests.Session,
     *,
+    auth: AuthManager,
     user_id: str,
     include_version_updates: IncludeVersionUpdates,
 ) -> Any | None:  # pragma: nocover
@@ -78,18 +82,24 @@ def _make_flashlight_notices_request(
         **make_flashlight_client_headers(),
     }
 
-    try:
+    def send(auth_headers: Mapping[str, str]) -> requests.Response:
         # NOTE: The flashlight API does **not** allow third-party access.
         #       Do not send any requests to any endpoints without explicit permission.
         #       Reach out on Discord for more information. https://discord.gg/k4FGUnEHYg
-        response = session.get(
+        return session.get(
             f"{FLASHLIGHT_API_URL}/v1/prism-notices",
-            headers=headers,
+            headers={**headers, **auth_headers},
             params={"includeVersionUpdates": include_version_updates},
             timeout=30,
         )
+
+    try:
+        response = send_authenticated(auth=auth, send=send)
     except RequestException:
         logger.exception("Failed to request flashlight notices")
+        return None
+    except NoSessionError:
+        logger.warning("Skipping flashlight notices - no auth session yet")
         return None
 
     if not response.ok:
@@ -176,19 +186,28 @@ def _parse_flashlight_notices(
 
 def get_flashlight_notices(
     *,
+    auth: AuthManager,
     user_id: str,
     include_version_updates: IncludeVersionUpdates,
-) -> tuple[FlashlightNotice, ...]:  # pragma: nocover
-    """Get flashlight prism notices for the user"""
+) -> tuple[FlashlightNotice, ...] | None:  # pragma: nocover
+    """
+    Get flashlight prism notices for the user
+
+    None means the request failed and is worth retrying - an empty tuple means it
+    succeeded and there is nothing to show. The caller needs the difference,
+    because this is how users learn a new version exists, and it is fetched once
+    per run.
+    """
     session = make_prism_requests_session()  # TODO: reuse shared session
 
     response_json = _make_flashlight_notices_request(
         session=session,
+        auth=auth,
         user_id=user_id,
         include_version_updates=include_version_updates,
     )
 
     if response_json is None:
-        return ()
+        return None
 
     return _parse_flashlight_notices(response_json, get_time_seconds=time.monotonic)

--- a/src/prism/flashlight/notices.py
+++ b/src/prism/flashlight/notices.py
@@ -101,6 +101,13 @@ def _make_flashlight_notices_request(
     except NoSessionError:
         logger.warning("Skipping flashlight notices - no auth session yet")
         return None
+    # TODO: `SessionRecoveryError` is not caught here, and this endpoint is behind
+    #       the bearer middleware, so it does 401 on a dead session. The exception
+    #       propagates through `get_flashlight_notices` into
+    #       `NoticeCheckerThread.run`, which has no handler either - the thread dies
+    #       with an unhandled traceback, skipping the retries we just added, and the
+    #       user gets no notices at all (including the new-version prompt) until
+    #       restart.
 
     if not response.ok:
         logger.error(
@@ -110,6 +117,11 @@ def _make_flashlight_notices_request(
         return None
 
     if response.status_code == 204:
+        # TODO: `None` now means "the request failed and is worth retrying", so a
+        #       204 is misclassified: the caller would issue three requests with two
+        #       30s sleeps and log "Giving up on fetching flashlight notices" for a
+        #       response that succeeded. Latent - the server never sends 204 on this
+        #       route today - but this branch now says the opposite of what it means.
         return None
 
     try:

--- a/src/prism/flashlight/tags.py
+++ b/src/prism/flashlight/tags.py
@@ -1,11 +1,14 @@
 import functools
 import logging
+from collections.abc import Mapping
 from json import JSONDecodeError
 
 import requests
 from requests.exceptions import RequestException
 
 from prism.errors import APIError, APIKeyError
+from prism.flashlight.auth.manager import AuthManager
+from prism.flashlight.auth.request import send_authenticated
 from prism.flashlight.headers import make_flashlight_client_headers
 from prism.flashlight.url import FLASHLIGHT_API_URL
 from prism.player import Tags, TagSeverity
@@ -20,12 +23,14 @@ class FlashlightTagsProvider:
         self,
         *,
         session: requests.Session,
+        auth: AuthManager,
         retry_limit: int,
         initial_timeout: float,
     ) -> None:
         self._retry_limit = retry_limit
         self._initial_timeout = initial_timeout
         self._session = session
+        self._auth = auth
         self._limiter = RateLimiter(limit=120, window=60)
 
     @property
@@ -45,15 +50,27 @@ class FlashlightTagsProvider:
         if urchin_api_key:
             headers["X-Urchin-Api-Key"] = urchin_api_key
 
-        try:
+        def send(auth_headers: Mapping[str, str]) -> requests.Response:
             # Uphold our prescribed rate-limits
             with self._limiter:
-                response = self._session.get(url, headers=headers, timeout=10)
+                return self._session.get(
+                    url, headers={**headers, **auth_headers}, timeout=10
+                )
+
+        try:
+            response = send_authenticated(auth=self._auth, send=send)
         except RequestException as e:
             raise ExecutionError(
                 "Request to flashlight failed due to an unknown error"
             ) from e
 
+        # NOTE: This endpoint answers 401 both for an invalid urchin API key and
+        #       for an auth session flashlight won't accept. A 401 only reaches
+        #       this point when send_authenticated established that our session is
+        #       *not* the cause - otherwise it raises SessionRecoveryError - so
+        #       this one is the urchin key's. That distinction matters because
+        #       APIKeyError latches urchin_api_key_invalid for the rest of the
+        #       process, which would stop us sending a perfectly good key.
         if response.status_code == 401:
             raise APIKeyError(
                 "Request to flashlight failed with HTTP 401 Unauthorized - "

--- a/src/prism/overlay/__main__.py
+++ b/src/prism/overlay/__main__.py
@@ -4,6 +4,7 @@ Parse the chat on Hypixel to detect players in your party and bedwars lobby
 Run from the root dir by `python -m prism.overlay [--logfile <path-to-logfile>]`
 """
 
+import functools
 import logging
 import sys
 import time
@@ -68,6 +69,9 @@ def main() -> None:  # pragma: nocover
 
     # Import late so we can patch ssl certs in requests
     from prism.flashlight.account import FlashlightAccountProvider
+    from prism.flashlight.auth.anonymous import AnonymousLogin
+    from prism.flashlight.auth.endpoints import refresh_session
+    from prism.flashlight.auth.manager import AuthManager
     from prism.flashlight.tags import FlashlightTagsProvider
     from prism.overlay.controller import OverlayController
     from prism.overlay.output.overlay.run_overlay import run_overlay
@@ -79,16 +83,29 @@ def main() -> None:  # pragma: nocover
 
     session = make_prism_requests_session()
 
+    # Start authenticating right away, before the (possibly interactive) logfile
+    # selection, so the login round trip overlaps the rest of startup. Every
+    # flashlight request waits for the session this establishes.
+    auth = AuthManager(
+        login_method=AnonymousLogin(requests_session=session, user_id=settings.user_id),
+        refresh_session=functools.partial(refresh_session, requests_session=session),
+    )
+    auth.start()
+
     account_provider = FlashlightAccountProvider(
-        retry_limit=5, initial_timeout=2, session=session
+        retry_limit=5, initial_timeout=2, session=session, auth=auth
     )
     player_provider = StrangePlayerProvider(
-        retry_limit=5, initial_timeout=2, get_time_ns=time.time_ns, session=session
+        retry_limit=5,
+        initial_timeout=2,
+        get_time_ns=time.time_ns,
+        session=session,
+        auth=auth,
     )
     # Use placeholder winstreak provider - no actual API integration
     winstreak_provider = PlaceholderWinstreakProvider()
     tags_provider = FlashlightTagsProvider(
-        retry_limit=5, initial_timeout=2, session=session
+        retry_limit=5, initial_timeout=2, session=session, auth=auth
     )
 
     controller = OverlayController(
@@ -116,7 +133,7 @@ def main() -> None:  # pragma: nocover
 
     controller.ready = True
 
-    run_overlay(controller, loglines)
+    run_overlay(controller, loglines, auth)
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/src/prism/overlay/output/overlay/run_overlay.py
+++ b/src/prism/overlay/output/overlay/run_overlay.py
@@ -3,6 +3,7 @@ import math
 import time
 from collections.abc import Iterable
 
+from prism.flashlight.auth.manager import AuthManager
 from prism.overlay.behaviour import get_cached_player_or_enqueue_request, should_redraw
 from prism.overlay.controller import OverlayController
 from prism.overlay.output.cells import InfoCellValue
@@ -88,9 +89,10 @@ def get_stat_list(controller: OverlayController) -> list[Player] | None:
 def run_overlay(
     controller: OverlayController,
     loglines: Iterable[str],
+    auth: AuthManager,
 ) -> None:  # pragma: nocover
     """Run the overlay"""
-    start_threads(controller, loglines)
+    start_threads(controller, loglines, auth)
 
     def get_new_data() -> tuple[bool, list[InfoCellValue], list[OverlayRowData] | None]:
         # Store a persistent view to the current state

--- a/src/prism/overlay/threading.py
+++ b/src/prism/overlay/threading.py
@@ -4,6 +4,7 @@ import threading
 import time
 from collections.abc import Iterable
 
+from prism.flashlight.auth.manager import AuthManager
 from prism.flashlight.notices import IncludeVersionUpdates, get_flashlight_notices
 from prism.overlay.behaviour import get_and_cache_player
 from prism.overlay.controller import OverlayController
@@ -13,6 +14,12 @@ from prism.overlay.process_event import process_loglines
 from prism.overlay.rich_presence import RPCThread
 
 logger = logging.getLogger(__name__)
+
+# How hard the notice checker tries. Notices are fetched once per launch, so a
+# single failure otherwise costs the user every notice - including the new-version
+# prompt - until they restart.
+NOTICE_FETCH_ATTEMPTS = 3
+NOTICE_RETRY_DELAY_SECONDS = 30.0
 
 
 class UpdateStateThread(threading.Thread):  # pragma: nocover
@@ -81,9 +88,11 @@ class NoticeCheckerThread(threading.Thread):  # pragma: nocover
     def __init__(
         self,
         controller: OverlayController,
+        auth: AuthManager,
     ) -> None:
         super().__init__(daemon=True)  # Don't block the process from exiting
         self.controller = controller
+        self.auth = auth
 
     def run(self) -> None:
         """Fetch the notices and store them in the controller"""
@@ -96,11 +105,27 @@ class NoticeCheckerThread(threading.Thread):  # pragma: nocover
         else:
             include_version_updates = "minor"
 
-        notices = get_flashlight_notices(
-            user_id=settings.user_id,
-            include_version_updates=include_version_updates,
+        # Retried, because this thread runs once per launch and it is how users
+        # learn that a new version exists. A single failure - a flaky network, or
+        # the auth session not being established yet - used to mean no notices at
+        # all until the next restart.
+        for attempt in range(NOTICE_FETCH_ATTEMPTS):
+            if attempt > 0:
+                time.sleep(NOTICE_RETRY_DELAY_SECONDS)
+
+            notices = get_flashlight_notices(
+                auth=self.auth,
+                user_id=settings.user_id,
+                include_version_updates=include_version_updates,
+            )
+            if notices is not None:
+                self.controller.flashlight_notices = notices
+                return
+
+        logger.warning(
+            f"Giving up on fetching flashlight notices "
+            f"after {NOTICE_FETCH_ATTEMPTS} attempts"
         )
-        self.controller.flashlight_notices = notices
 
 
 class AutoWhoThread(threading.Thread):  # pragma: nocover
@@ -161,7 +186,7 @@ class AutoWhoThread(threading.Thread):  # pragma: nocover
 
 
 def start_threads(
-    controller: OverlayController, loglines: Iterable[str]
+    controller: OverlayController, loglines: Iterable[str], auth: AuthManager
 ) -> None:  # pragma: nocover
     """Spawn threads that perform the state updates and stats downloading"""
 
@@ -181,4 +206,5 @@ def start_threads(
     # Spawn thread to check for flashlight information
     NoticeCheckerThread(
         controller=controller,
+        auth=auth,
     ).start()

--- a/src/prism/stats.py
+++ b/src/prism/stats.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import functools
 import math
 import sys
 from collections.abc import Mapping
@@ -15,6 +16,9 @@ from prism.errors import (
     PlayerNotFoundError,
 )
 from prism.flashlight.account import FlashlightAccountProvider
+from prism.flashlight.auth.anonymous import AnonymousLogin
+from prism.flashlight.auth.endpoints import refresh_session
+from prism.flashlight.auth.manager import AuthManager
 from prism.hypixel import (
     HypixelAPIKeyHolder,
     MissingBedwarsStatsError,
@@ -29,8 +33,15 @@ key_holder = HypixelAPIKeyHolder(api_key)
 
 session = make_prism_requests_session()
 
+AUTH = AuthManager(
+    login_method=AnonymousLogin(requests_session=session, user_id="get_stats_script"),
+    refresh_session=functools.partial(refresh_session, requests_session=session),
+)
+# NOTE: Started from main(), not here. Importing a module should not spawn a
+#       thread that does network i/o.
+
 ACCOUNT_PROVIDER = FlashlightAccountProvider(
-    retry_limit=0, initial_timeout=0, session=session
+    retry_limit=0, initial_timeout=0, session=session, auth=AUTH
 )
 
 
@@ -198,6 +209,8 @@ def get_and_display(username: str) -> None:
 
 
 def main() -> None:
+    AUTH.start()
+
     for i, username in enumerate(sys.argv[1:]):
         get_and_display(username)
 

--- a/src/prism/strange.py
+++ b/src/prism/strange.py
@@ -1,12 +1,14 @@
 import functools
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from json import JSONDecodeError
 
 import requests
 from requests.exceptions import RequestException
 
 from prism.errors import APIError, APIKeyError, APIThrottleError, PlayerNotFoundError
+from prism.flashlight.auth.manager import AuthManager
+from prism.flashlight.auth.request import send_authenticated
 from prism.flashlight.headers import make_flashlight_client_headers
 from prism.hypixel import create_known_player, get_playerdata_field
 from prism.player import KnownPlayer
@@ -96,6 +98,7 @@ class StrangePlayerProvider:
         self,
         *,
         session: requests.Session,
+        auth: AuthManager,
         retry_limit: int,
         initial_timeout: float,
         get_time_ns: Callable[[], int],
@@ -104,6 +107,7 @@ class StrangePlayerProvider:
         self._initial_timeout = initial_timeout
         self._get_time_ns = get_time_ns
         self._session = session
+        self._auth = auth
         self._limiter = RateLimiter(limit=120, window=60)
 
     @property
@@ -118,16 +122,15 @@ class StrangePlayerProvider:
         user_id: str,
         last_try: bool,
     ) -> requests.Response:  # pragma: nocover
-        try:
+        headers = {"X-User-Id": user_id, **make_flashlight_client_headers()}
+
+        def send(auth_headers: Mapping[str, str]) -> requests.Response:
             # Uphold our prescribed rate-limits
             with self._limiter:
-                response = self._session.get(
-                    url,
-                    headers={
-                        "X-User-Id": user_id,
-                        **make_flashlight_client_headers(),
-                    },
-                )
+                return self._session.get(url, headers={**headers, **auth_headers})
+
+        try:
+            response = send_authenticated(auth=self._auth, send=send)
         except RequestException as e:
             raise ExecutionError(
                 "Request to AntiSniper API failed due to an unknown error"

--- a/tests/prism/auth_utils.py
+++ b/tests/prism/auth_utils.py
@@ -1,0 +1,156 @@
+"""Helpers for testing code that needs a flashlight auth session"""
+
+import contextlib
+import itertools
+import threading
+import time
+from collections.abc import Callable, Iterator, Sequence
+
+from prism.flashlight.auth.manager import AuthManager
+from prism.flashlight.auth.session import Session
+
+# Not a real session id - flashlight's are `flsess_` plus 32 random bytes
+TEST_SESSION_ID = "flsess_test_session_id"
+
+
+def make_session(
+    *,
+    session_id: str = TEST_SESSION_ID,
+    tier: str = "anonymous",
+    can_refresh: bool = True,
+    refresh_in_seconds: float = 3300.0,
+) -> Session:
+    return Session(
+        session_id=session_id,
+        tier=tier,
+        can_refresh=can_refresh,
+        refresh_in_seconds=refresh_in_seconds,
+    )
+
+
+class QueuedLoginMethod:
+    """A `LoginMethod` returning (or raising) queued results, in order"""
+
+    tier = "test"
+
+    def __init__(self, results: Sequence[Session | Exception] = ()) -> None:
+        self.results = list(results)
+        self.calls = 0
+
+    def log_in(self) -> Session:
+        self.calls += 1
+        assert self.results, "Unexpected call to log_in"
+        result = self.results.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+class QueuedRefresh:
+    """A refresh callable returning (or raising) queued results, in order"""
+
+    def __init__(self, results: Sequence[Session | Exception] = ()) -> None:
+        self.results = list(results)
+        self.session_ids: list[str] = []
+
+    def __call__(self, session_id: str) -> Session:
+        self.session_ids.append(session_id)
+        assert self.results, "Unexpected call to refresh"
+        result = self.results.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+def make_auth_manager(
+    *,
+    login_results: Sequence[Session | Exception] = (),
+    refresh_results: Sequence[Session | Exception] = (),
+    monotonic: Callable[[], float] | None = None,
+) -> tuple[AuthManager, QueuedLoginMethod, QueuedRefresh]:
+    """
+    Return an `AuthManager` with a frozen clock and no jitter
+
+    The auth thread is not started - tests drive `reconcile` themselves, which is
+    also how the manager is meant to be reasoned about: a single writer taking one
+    step at a time.
+
+    Pass `monotonic=time.monotonic` for the few tests that need time to pass.
+    """
+    login_method = QueuedLoginMethod(login_results)
+    refresh = QueuedRefresh(refresh_results)
+    manager = AuthManager(
+        login_method=login_method,
+        refresh_session=refresh,
+        monotonic=(lambda: 0.0) if monotonic is None else monotonic,
+        jitter=lambda: 1.0,
+    )
+    return manager, login_method, refresh
+
+
+def make_real_clock_auth_manager() -> AuthManager:
+    """Return an `AuthManager` on the real clock, holding no session"""
+    manager, _, _ = make_auth_manager(monotonic=time.monotonic)
+    return manager
+
+
+def make_fast_forward_auth_manager() -> AuthManager:
+    """
+    Return an `AuthManager` whose clock jumps, so every wait times out at once
+
+    NOTE: The frozen clock in `make_auth_manager` must never be made to wait -
+    the manager's wait loops recompute how much of the timeout is left from the
+    clock, so a clock that never advances never reaches the deadline. Real
+    monotonic clocks always advance; this is purely a test concern.
+    """
+    clock = itertools.count(0.0, 100.0)
+    manager, _, _ = make_auth_manager(monotonic=lambda: next(clock))
+    return manager
+
+
+@contextlib.contextmanager
+def running_auth_thread(manager: AuthManager) -> Iterator[list[BaseException]]:
+    """
+    Stand in for the auth thread, reconciling whenever it is asked to
+
+    Only usable once the manager already holds a session - otherwise it would
+    reconcile in a loop, since a manager with no session always wants one.
+
+    Yields the list of exceptions reconcile raised. Swallowing them mirrors the
+    real thread, which must survive a bug rather than take the overlay with it.
+    """
+    stop = threading.Event()
+    errors: list[BaseException] = []
+
+    def run() -> None:
+        while not stop.is_set():
+            if manager.seconds_until_next_action() <= 0:
+                try:
+                    manager.reconcile()
+                except Exception as e:
+                    errors.append(e)
+                    return
+            else:
+                time.sleep(0.001)
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    try:
+        yield errors
+    finally:
+        stop.set()
+        thread.join(timeout=5)
+        assert not thread.is_alive()
+
+
+def make_authenticated_manager() -> AuthManager:
+    """Return an `AuthManager` holding a session, for tests that just need one"""
+    manager, _, _ = make_auth_manager(login_results=[make_session()])
+    manager.reconcile()
+    return manager
+
+
+def make_unauthenticated_manager() -> AuthManager:
+    """Return an `AuthManager` that must never be asked for a session"""
+    manager, _, _ = make_auth_manager()
+    return manager

--- a/tests/prism/flashlight/auth/test_auth_manager.py
+++ b/tests/prism/flashlight/auth/test_auth_manager.py
@@ -1,0 +1,362 @@
+import time
+
+import pytest
+
+from prism.flashlight.auth.errors import (
+    AuthError,
+    RefreshTooSoonError,
+    SessionExpiredError,
+)
+from prism.flashlight.auth.manager import (
+    INITIAL_BACKOFF_SECONDS,
+    MAX_BACKOFF_SECONDS,
+    TOO_SOON_REFRESH_DELAY_SECONDS,
+)
+from tests.prism.auth_utils import (
+    make_auth_manager,
+    make_real_clock_auth_manager,
+    make_session,
+    running_auth_thread,
+)
+
+
+def test_starts_with_no_session_and_wants_to_act_now() -> None:
+    manager, login, refresh = make_auth_manager()
+
+    assert manager.wait_for_session(timeout=0) is None
+    assert manager.seconds_until_next_action() == 0.0
+    assert manager.consecutive_failures == 0
+    assert manager.last_error is None
+    assert login.calls == 0
+
+
+def test_reconcile_logs_in_when_there_is_no_session() -> None:
+    session = make_session()
+    manager, login, refresh = make_auth_manager(login_results=[session])
+
+    manager.reconcile()
+
+    assert manager.wait_for_session(timeout=0) is session
+    assert login.calls == 1
+    assert refresh.session_ids == []
+    # Next action is the proactive refresh the server asked for
+    assert manager.seconds_until_next_action() == session.refresh_in_seconds
+
+
+def test_reconcile_refreshes_the_session_it_holds() -> None:
+    session = make_session(session_id="flsess_first")
+    refreshed = make_session(session_id="flsess_first", refresh_in_seconds=6600.0)
+    manager, login, refresh = make_auth_manager(
+        login_results=[session], refresh_results=[refreshed]
+    )
+
+    manager.reconcile()
+    manager.reconcile()
+
+    assert manager.wait_for_session(timeout=0) is refreshed
+    assert refresh.session_ids == ["flsess_first"]
+    # No second login - the bearer was enough to pay for the identity again
+    assert login.calls == 1
+
+
+def test_reconcile_logs_in_again_when_the_session_is_finished() -> None:
+    session = make_session(session_id="flsess_dead")
+    new_session = make_session(session_id="flsess_new")
+    manager, login, refresh = make_auth_manager(
+        login_results=[session, new_session],
+        refresh_results=[SessionExpiredError("finished")],
+    )
+
+    manager.reconcile()
+    manager.reconcile()
+
+    assert manager.wait_for_session(timeout=0) is new_session
+    assert login.calls == 2
+
+
+def test_reconcile_skips_a_refresh_that_would_be_pointless() -> None:
+    """canRefresh=False means the server already told us not to bother"""
+    session = make_session(can_refresh=False)
+    new_session = make_session(session_id="flsess_new")
+    manager, login, refresh = make_auth_manager(login_results=[session, new_session])
+
+    manager.reconcile()
+    manager.reconcile()
+
+    assert manager.wait_for_session(timeout=0) is new_session
+    assert login.calls == 2
+    assert refresh.session_ids == []
+
+
+def test_reconcile_keeps_the_session_when_a_refresh_is_too_soon() -> None:
+    """A 429 means the session is untouched - re-logging in would be a stampede"""
+    session = make_session(refresh_in_seconds=60.0)
+    manager, login, refresh = make_auth_manager(
+        login_results=[session], refresh_results=[RefreshTooSoonError("too soon")]
+    )
+
+    manager.reconcile()
+    manager.reconcile()
+
+    assert manager.wait_for_session(timeout=0) is session
+    assert login.calls == 1
+    assert manager.consecutive_failures == 0
+    assert manager.last_error is None
+    assert manager.seconds_until_next_action() == TOO_SOON_REFRESH_DELAY_SECONDS
+
+
+def test_a_too_soon_refusal_never_schedules_earlier_than_the_session_wants() -> None:
+    """
+    Otherwise one 429 becomes a loop of them
+
+    A session refused as too fresh is good until its own refresh point, and the
+    server's minimum interval is longer than the too-soon delay - so moving the
+    next attempt *forward* would just walk into the same refusal repeatedly, each
+    time logging a warning that claims no honest client sees it.
+    """
+    session = make_session(refresh_in_seconds=3300.0)
+    manager, login, refresh = make_auth_manager(
+        login_results=[session], refresh_results=[RefreshTooSoonError("too soon")]
+    )
+
+    manager.reconcile()
+    manager.reconcile()
+
+    assert manager.seconds_until_next_action() == 3300.0
+
+
+def test_a_request_arriving_mid_pass_does_not_provoke_a_second_one() -> None:
+    """
+    The refresh hint fires exactly when our own timer does
+
+    Flashlight sets X-Auth-Refresh from the same point refreshInSeconds counts
+    down to, so a lobby fan-out reports the hint while the refresh it asked for is
+    still in flight. Leaving that request queued would make the auth thread
+    refresh again immediately - straight into a too-soon 429.
+    """
+    session = make_session(session_id="flsess_first")
+    refreshed = make_session(session_id="flsess_first")
+    manager, login, refresh = make_auth_manager(
+        login_results=[session], refresh_results=[refreshed]
+    )
+    manager.reconcile()
+
+    # A response carrying the hint, seen while the pass below is conceptually in
+    # flight: it is reported against the session that pass is already handling.
+    manager.note_refresh_hint(session)
+    manager.reconcile()
+
+    assert manager.wait_for_session(timeout=0) is refreshed
+    assert manager.seconds_until_next_action() == refreshed.refresh_in_seconds
+
+
+def test_reconcile_records_a_bug_as_a_failure_before_re_raising() -> None:
+    """
+    Otherwise every request pays the full session wait for a pass that can't come
+
+    The auth thread sleeps off an unexpected error, so without a retry deadline
+    recover_from_unauthorized would keep queueing passes and blocking on them.
+    """
+    session = make_session()
+    manager, login, refresh = make_auth_manager(
+        login_results=[session], refresh_results=[ValueError("a bug, not a 401")]
+    )
+    manager.reconcile()
+
+    with pytest.raises(ValueError):
+        manager.reconcile()
+
+    assert manager.consecutive_failures == 1
+    assert manager.seconds_until_next_action() == INITIAL_BACKOFF_SECONDS
+    # And a request that 401s now fails fast instead of waiting for a pass
+    recovery = manager.recover_from_unauthorized(session, timeout=5)
+    assert recovery.session is None
+    assert not recovery.session_confirmed
+
+
+def test_reconcile_records_failures_and_backs_off() -> None:
+    manager, login, refresh = make_auth_manager(
+        login_results=[
+            AuthError("no network"),
+            AuthError("no network"),
+            make_session(),
+        ]
+    )
+
+    manager.reconcile()
+    assert manager.wait_for_session(timeout=0) is None
+    assert manager.consecutive_failures == 1
+    assert manager.last_error == "no network"
+    assert manager.seconds_until_next_action() == INITIAL_BACKOFF_SECONDS
+
+    manager.reconcile()
+    assert manager.consecutive_failures == 2
+    assert manager.seconds_until_next_action() == INITIAL_BACKOFF_SECONDS * 2
+
+    manager.reconcile()
+    assert manager.wait_for_session(timeout=0) is not None
+    assert manager.consecutive_failures == 0
+    assert manager.last_error is None
+
+
+def test_reconcile_caps_the_backoff() -> None:
+    manager, login, refresh = make_auth_manager(login_results=[AuthError("nope")] * 20)
+
+    for _ in range(20):
+        manager.reconcile()
+
+    assert manager.seconds_until_next_action() == MAX_BACKOFF_SECONDS
+
+
+def test_reconcile_discards_a_session_it_knows_is_dead() -> None:
+    """
+    A token flashlight has rejected must not be handed out again
+
+    Validating an unknown bearer costs the server an uncached transaction, so
+    retrying with a token we know is dead is not a neutral act.
+    """
+    session = make_session()
+    manager, login, refresh = make_auth_manager(
+        login_results=[session, AuthError("login is down too")],
+        refresh_results=[SessionExpiredError("finished")],
+    )
+
+    manager.reconcile()
+    manager.reconcile()
+
+    assert manager.wait_for_session(timeout=0) is None
+    assert manager.consecutive_failures == 1
+
+
+def test_wait_for_session_gives_up_when_there_is_nothing_to_wait_for() -> None:
+    """Bounded, because the denick dialog waits on the tkinter thread"""
+    manager = make_real_clock_auth_manager()
+
+    started = time.monotonic()
+    assert manager.wait_for_session(timeout=0.05) is None
+    assert time.monotonic() - started >= 0.05
+
+
+def test_recover_from_unauthorized_adopts_a_session_someone_else_got() -> None:
+    """The first 401 of a fan-out does the work - the rest just adopt the result"""
+    stale = make_session(session_id="flsess_stale")
+    current = make_session(session_id="flsess_current")
+    manager, login, refresh = make_auth_manager(login_results=[current])
+
+    manager.reconcile()
+
+    recovery = manager.recover_from_unauthorized(stale, timeout=0)
+    assert recovery.session is current
+    assert not recovery.session_confirmed
+    # Nothing was asked of the server
+    assert login.calls == 1
+    assert refresh.session_ids == []
+
+
+def test_recover_from_unauthorized_confirms_a_session_the_server_vouched_for() -> None:
+    """
+    A too-soon refusal is the server saying our session is fine
+
+    Which is the only thing that lets /v1/tags conclude a 401 was its Urchin API
+    key's rather than ours.
+    """
+    session = make_session()
+    manager, login, refresh = make_auth_manager(
+        login_results=[session], refresh_results=[RefreshTooSoonError("too soon")]
+    )
+    manager.reconcile()
+
+    with running_auth_thread(manager):
+        recovery = manager.recover_from_unauthorized(session, timeout=5)
+
+    assert recovery.session is None
+    assert recovery.session_confirmed
+
+
+def test_recover_from_unauthorized_does_not_confirm_what_it_could_not_check() -> None:
+    """
+    16 stats threads must not out-vote the auth thread's backoff
+
+    And while auth is failing we have no verdict on the session, so nothing may be
+    told that its own 401 is explained.
+    """
+    session = make_session()
+    manager, login, refresh = make_auth_manager(
+        login_results=[session],
+        refresh_results=[AuthError("no network")],
+    )
+
+    manager.reconcile()
+    manager.reconcile()
+
+    recovery = manager.recover_from_unauthorized(session, timeout=0)
+    assert recovery.session is None
+    assert not recovery.session_confirmed
+    # No pass was requested, so the auth thread still gets to sleep off its backoff
+    assert manager.seconds_until_next_action() == INITIAL_BACKOFF_SECONDS
+
+
+def test_recover_from_unauthorized_has_no_verdict_when_the_wait_times_out() -> None:
+    session = make_session()
+    manager, login, refresh = make_auth_manager(login_results=[session])
+
+    manager.reconcile()
+
+    # No auth thread running, so the requested pass never completes
+    recovery = manager.recover_from_unauthorized(session, timeout=0)
+    assert recovery.session is None
+    assert not recovery.session_confirmed
+
+
+def test_recover_from_unauthorized_waits_for_the_auth_thread() -> None:
+    session = make_session(session_id="flsess_lapsed")
+    renewed = make_session(session_id="flsess_lapsed", refresh_in_seconds=6600.0)
+    manager, login, refresh = make_auth_manager(
+        login_results=[session], refresh_results=[renewed]
+    )
+
+    manager.reconcile()
+    observed = manager.wait_for_session(timeout=0)
+    assert observed is session
+
+    with running_auth_thread(manager):
+        recovery = manager.recover_from_unauthorized(observed, timeout=5)
+
+    assert recovery.session is renewed
+    assert not recovery.session_confirmed
+    assert refresh.session_ids == ["flsess_lapsed"]
+
+
+def test_note_refresh_hint_asks_for_a_pass() -> None:
+    session = make_session()
+    manager, login, refresh = make_auth_manager(login_results=[session])
+
+    manager.reconcile()
+    assert manager.seconds_until_next_action() == session.refresh_in_seconds
+
+    manager.note_refresh_hint(session)
+
+    assert manager.seconds_until_next_action() == 0.0
+
+
+def test_note_refresh_hint_ignores_a_stale_session() -> None:
+    session = make_session(session_id="flsess_current")
+    manager, login, refresh = make_auth_manager(login_results=[session])
+
+    manager.reconcile()
+    manager.note_refresh_hint(make_session(session_id="flsess_stale"))
+
+    assert manager.seconds_until_next_action() == session.refresh_in_seconds
+
+
+def test_note_refresh_hint_respects_the_backoff() -> None:
+    session = make_session()
+    manager, login, refresh = make_auth_manager(
+        login_results=[session], refresh_results=[AuthError("no network")]
+    )
+
+    manager.reconcile()
+    manager.reconcile()
+    manager.note_refresh_hint(session)
+
+    assert manager.seconds_until_next_action() == INITIAL_BACKOFF_SECONDS

--- a/tests/prism/flashlight/auth/test_auth_proof_of_work.py
+++ b/tests/prism/flashlight/auth/test_auth_proof_of_work.py
@@ -1,0 +1,126 @@
+import hashlib
+
+import pytest
+
+from prism.flashlight.auth import proof_of_work
+from prism.flashlight.auth.errors import AuthError
+from prism.flashlight.auth.proof_of_work import (
+    ALGORITHM_SHA256_LEADING_ZEROS,
+    MAX_DIFFICULTY,
+    Challenge,
+    leading_zero_bits,
+    parse_challenge_response,
+    solve_challenge,
+)
+
+# A real response from POST /v1/auth/anonymous/challenge
+VALID_RESPONSE = {
+    "challenge": (
+        "eyJub25jZSI6IkFBQUFBQUFBQUFBQUFBQUFBQSIsInVzZXJJZCI6InByaXNtIn0"
+        ".c3VyZWx5LW5vdC1hLXJlYWwtc2lnbmF0dXJlLWJ1dC1sb25nLWVub3VnaA"
+    ),
+    "algorithm": ALGORITHM_SHA256_LEADING_ZEROS,
+    "difficulty": 0,
+    "expiresInSeconds": 60,
+}
+
+
+def make_challenge(*, difficulty: int = 0, algorithm: str | None = None) -> Challenge:
+    return Challenge(
+        challenge="a-challenge",
+        algorithm=ALGORITHM_SHA256_LEADING_ZEROS if algorithm is None else algorithm,
+        difficulty=difficulty,
+    )
+
+
+def test_parse_challenge_response() -> None:
+    assert parse_challenge_response(VALID_RESPONSE) == Challenge(
+        challenge=VALID_RESPONSE["challenge"],  # type: ignore[arg-type]
+        algorithm=ALGORITHM_SHA256_LEADING_ZEROS,
+        difficulty=0,
+    )
+
+
+def test_parse_challenge_response_keeps_unknown_algorithms() -> None:
+    """Refusing an algorithm is solve_challenge's job, not the parser's"""
+    challenge = parse_challenge_response({**VALID_RESPONSE, "algorithm": "sha512-v2"})
+    assert challenge.algorithm == "sha512-v2"
+
+
+@pytest.mark.parametrize(
+    "response_json",
+    (
+        # Not a dict
+        None,
+        [],
+        "challenge",
+        # Bad challenge
+        {**VALID_RESPONSE, "challenge": ""},
+        {**VALID_RESPONSE, "challenge": None},
+        {**VALID_RESPONSE, "challenge": 123},
+        # Bad algorithm
+        {**VALID_RESPONSE, "algorithm": ""},
+        {**VALID_RESPONSE, "algorithm": None},
+        {**VALID_RESPONSE, "algorithm": 1},
+        # Bad difficulty
+        {**VALID_RESPONSE, "difficulty": None},
+        {**VALID_RESPONSE, "difficulty": "0"},
+        {**VALID_RESPONSE, "difficulty": 1.5},
+        {**VALID_RESPONSE, "difficulty": True},
+        {**VALID_RESPONSE, "difficulty": -1},
+    ),
+)
+def test_parse_challenge_response_invalid(response_json: object) -> None:
+    with pytest.raises(AuthError):
+        parse_challenge_response(response_json)
+
+
+@pytest.mark.parametrize(
+    "digest, bits",
+    (
+        (bytes([0xFF]) + bytes(31), 0),
+        (bytes([0x80]) + bytes(31), 0),
+        (bytes([0x7F]) + bytes(31), 1),
+        (bytes([0x01]) + bytes(31), 7),
+        (bytes([0x00, 0xFF]) + bytes(30), 8),
+        (bytes([0x00, 0x01]) + bytes(30), 15),
+        (bytes(32), 256),
+    ),
+)
+def test_leading_zero_bits(digest: bytes, bits: int) -> None:
+    assert leading_zero_bits(digest) == bits
+
+
+@pytest.mark.parametrize("difficulty", (0, 1, 4, 8))
+def test_solve_challenge(difficulty: int) -> None:
+    challenge = make_challenge(difficulty=difficulty)
+    solution = solve_challenge(challenge)
+
+    # A non-empty solution is required even at difficulty 0
+    assert solution
+
+    digest = hashlib.sha256(f"{challenge.challenge}:{solution}".encode()).digest()
+    assert leading_zero_bits(digest) >= difficulty
+
+
+def test_solve_challenge_at_difficulty_zero_is_one_hash() -> None:
+    assert solve_challenge(make_challenge(difficulty=0)) == "0"
+
+
+def test_solve_challenge_rejects_unknown_algorithm() -> None:
+    """A scheme we don't implement must be an error, never a guess"""
+    with pytest.raises(AuthError, match="Unsupported proof-of-work algorithm"):
+        solve_challenge(make_challenge(algorithm="sha256-leading-zeros-v2"))
+
+
+def test_solve_challenge_refuses_difficulty_above_the_ceiling() -> None:
+    """A server bug must not wedge the overlay in a hash loop"""
+    with pytest.raises(AuthError, match="Refusing proof-of-work difficulty"):
+        solve_challenge(make_challenge(difficulty=MAX_DIFFICULTY + 1))
+
+
+def test_solve_challenge_logs_noteworthy_difficulties(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(proof_of_work, "NOTEWORTHY_DIFFICULTY", 4)
+    assert solve_challenge(make_challenge(difficulty=4))

--- a/tests/prism/flashlight/auth/test_auth_request.py
+++ b/tests/prism/flashlight/auth/test_auth_request.py
@@ -1,0 +1,182 @@
+from collections.abc import Mapping, Sequence
+
+import pytest
+import requests
+
+from prism.flashlight.auth.errors import (
+    AuthError,
+    NoSessionError,
+    RefreshTooSoonError,
+    SessionRecoveryError,
+)
+from prism.flashlight.auth.request import (
+    REFRESH_HINT_HEADER,
+    bearer_headers,
+    send_authenticated,
+)
+from tests.prism.auth_utils import (
+    TEST_SESSION_ID,
+    make_auth_manager,
+    make_fast_forward_auth_manager,
+    make_session,
+    running_auth_thread,
+)
+
+
+def make_response(
+    status_code: int, *, refresh_hint: str | None = None
+) -> requests.Response:
+    response = requests.Response()
+    response.status_code = status_code
+    if refresh_hint is not None:
+        response.headers[REFRESH_HINT_HEADER] = refresh_hint
+    return response
+
+
+class RecordingSender:
+    """Records the auth headers it is called with, and returns queued responses"""
+
+    def __init__(self, responses: Sequence[requests.Response]) -> None:
+        self.responses = list(responses)
+        self.auth_headers: list[Mapping[str, str]] = []
+
+    def __call__(self, auth_headers: Mapping[str, str]) -> requests.Response:
+        self.auth_headers.append(auth_headers)
+        assert self.responses, "Unexpected request"
+        return self.responses.pop(0)
+
+
+def test_bearer_headers() -> None:
+    assert bearer_headers(make_session(session_id="flsess_abc")) == {
+        "Authorization": "Bearer flsess_abc"
+    }
+
+
+def test_send_authenticated() -> None:
+    manager, _, _ = make_auth_manager(login_results=[make_session()])
+    manager.reconcile()
+    send = RecordingSender([make_response(200)])
+
+    response = send_authenticated(auth=manager, send=send)
+
+    assert response.status_code == 200
+    assert send.auth_headers == [{"Authorization": f"Bearer {TEST_SESSION_ID}"}]
+
+
+def test_send_authenticated_without_a_session() -> None:
+    """A NoSessionError is an APIError, so every call site already handles it"""
+    manager = make_fast_forward_auth_manager()
+
+    with pytest.raises(NoSessionError):
+        send_authenticated(auth=manager, send=RecordingSender([]))
+
+
+def test_send_authenticated_retries_once_with_a_renewed_session() -> None:
+    lapsed = make_session(session_id="flsess_lapsed")
+    renewed = make_session(session_id="flsess_renewed")
+    manager, _, _ = make_auth_manager(login_results=[lapsed], refresh_results=[renewed])
+    manager.reconcile()
+    send = RecordingSender([make_response(401), make_response(200)])
+
+    with running_auth_thread(manager):
+        response = send_authenticated(auth=manager, send=send)
+
+    assert response.status_code == 200
+    assert send.auth_headers == [
+        {"Authorization": "Bearer flsess_lapsed"},
+        {"Authorization": "Bearer flsess_renewed"},
+    ]
+
+
+def test_send_authenticated_surfaces_a_401_the_server_says_is_not_ours() -> None:
+    """
+    /v1/tags answers 401 for an invalid Urchin API key too
+
+    Handing the 401 back is what lets that call site tell the two apart, and it
+    is also why the request is not retried with the same bearer. This is the real
+    shape of that case: the 401 provokes a refresh, the server refuses to touch a
+    session it considers too fresh, and so the 401 was never about the session.
+    """
+    session = make_session()
+    manager, _, _ = make_auth_manager(
+        login_results=[session], refresh_results=[RefreshTooSoonError("too soon")]
+    )
+    manager.reconcile()
+    send = RecordingSender([make_response(401)])
+
+    with running_auth_thread(manager):
+        response = send_authenticated(auth=manager, send=send)
+
+    assert response.status_code == 401
+    assert len(send.auth_headers) == 1
+
+
+def test_send_authenticated_raises_on_a_401_it_cannot_account_for() -> None:
+    """
+    An unexplained 401 must not be passed off as the caller's
+
+    /v1/tags would latch urchin_api_key_invalid for the rest of the process and
+    stop sending a perfectly good key, so "we could not check" has to be an error
+    rather than a 401 handed back.
+    """
+    session = make_session()
+    manager, _, _ = make_auth_manager(
+        login_results=[session], refresh_results=[AuthError("no network")]
+    )
+    manager.reconcile()
+    manager.reconcile()  # fails, so we are inside the backoff with no verdict
+
+    send = RecordingSender([make_response(401)])
+    with pytest.raises(SessionRecoveryError):
+        send_authenticated(auth=manager, send=send)
+
+    assert len(send.auth_headers) == 1
+
+
+def test_send_authenticated_acts_on_the_refresh_hint() -> None:
+    session = make_session()
+    manager, _, _ = make_auth_manager(login_results=[session])
+    manager.reconcile()
+    assert manager.seconds_until_next_action() > 0
+
+    send_authenticated(
+        auth=manager, send=RecordingSender([make_response(200, refresh_hint="1")])
+    )
+
+    assert manager.seconds_until_next_action() == 0.0
+
+
+def test_send_authenticated_acts_on_an_unknown_refresh_hint_value() -> None:
+    """Room is reserved for a richer value, and every value means "deal with it now" """
+    session = make_session()
+    manager, _, _ = make_auth_manager(login_results=[session])
+    manager.reconcile()
+
+    send_authenticated(
+        auth=manager, send=RecordingSender([make_response(200, refresh_hint="reauth")])
+    )
+
+    assert manager.seconds_until_next_action() == 0.0
+
+
+def test_send_authenticated_ignores_a_missing_refresh_hint() -> None:
+    session = make_session()
+    manager, _, _ = make_auth_manager(login_results=[session])
+    manager.reconcile()
+
+    send_authenticated(auth=manager, send=RecordingSender([make_response(200)]))
+
+    assert manager.seconds_until_next_action() == session.refresh_in_seconds
+
+
+def test_send_authenticated_reads_the_refresh_hint_from_the_retry() -> None:
+    lapsed = make_session(session_id="flsess_lapsed")
+    renewed = make_session(session_id="flsess_renewed")
+    manager, _, _ = make_auth_manager(login_results=[lapsed], refresh_results=[renewed])
+    manager.reconcile()
+    send = RecordingSender([make_response(401), make_response(200, refresh_hint="1")])
+
+    with running_auth_thread(manager):
+        send_authenticated(auth=manager, send=send)
+
+    assert manager.seconds_until_next_action() == 0.0

--- a/tests/prism/flashlight/auth/test_auth_session.py
+++ b/tests/prism/flashlight/auth/test_auth_session.py
@@ -1,0 +1,84 @@
+import pytest
+
+from prism.flashlight.auth.errors import AuthError
+from prism.flashlight.auth.session import (
+    MIN_REFRESH_DELAY_SECONDS,
+    Session,
+    parse_session_response,
+)
+
+# A real response from POST /v1/auth/anonymous/login, with the session id replaced
+VALID_RESPONSE = {
+    "sessionId": "flsess_bm90LWEtcmVhbC1zZXNzaW9uLWlkLW9idmlvdXNsee8",
+    "tier": "anonymous",
+    "expiresInSeconds": 3600,
+    "refreshUntilInSeconds": 7200,
+    "refreshInSeconds": 3300,
+    "canRefresh": True,
+}
+
+
+def test_parse_session_response() -> None:
+    assert parse_session_response(VALID_RESPONSE) == Session(
+        session_id="flsess_bm90LWEtcmVhbC1zZXNzaW9uLWlkLW9idmlvdXNsee8",
+        tier="anonymous",
+        can_refresh=True,
+        refresh_in_seconds=3300.0,
+    )
+
+
+def test_parse_session_response_cannot_refresh() -> None:
+    session = parse_session_response({**VALID_RESPONSE, "canRefresh": False})
+    assert not session.can_refresh
+
+
+def test_parse_session_response_ignores_informational_fields() -> None:
+    """Only refreshInSeconds is acted on, so the others may be anything"""
+    session = parse_session_response(
+        {**VALID_RESPONSE, "expiresInSeconds": "?", "refreshUntilInSeconds": None},
+    )
+    assert session.refresh_in_seconds == 3300.0
+
+
+@pytest.mark.parametrize("refresh_in_seconds", (0, 1, 59, 59.9))
+def test_parse_session_response_clamps_short_refresh_delays(
+    refresh_in_seconds: float,
+) -> None:
+    """A server bug must not be able to turn the auth thread into a hot loop"""
+    session = parse_session_response(
+        {**VALID_RESPONSE, "refreshInSeconds": refresh_in_seconds},
+    )
+    assert session.refresh_in_seconds == MIN_REFRESH_DELAY_SECONDS
+
+
+@pytest.mark.parametrize(
+    "response_json",
+    (
+        # Not a dict
+        None,
+        [],
+        "session",
+        # Bad sessionId
+        {**VALID_RESPONSE, "sessionId": ""},
+        {**VALID_RESPONSE, "sessionId": None},
+        {**VALID_RESPONSE, "sessionId": 123},
+        # Bad tier
+        {**VALID_RESPONSE, "tier": ""},
+        {**VALID_RESPONSE, "tier": None},
+        {**VALID_RESPONSE, "tier": 1},
+        # Bad canRefresh
+        {**VALID_RESPONSE, "canRefresh": None},
+        {**VALID_RESPONSE, "canRefresh": "true"},
+        {**VALID_RESPONSE, "canRefresh": 1},
+        # Bad refreshInSeconds
+        {**VALID_RESPONSE, "refreshInSeconds": None},
+        {**VALID_RESPONSE, "refreshInSeconds": "3300"},
+        {**VALID_RESPONSE, "refreshInSeconds": True},
+        {**VALID_RESPONSE, "refreshInSeconds": -1},
+        {**VALID_RESPONSE, "refreshInSeconds": float("inf")},
+        {**VALID_RESPONSE, "refreshInSeconds": float("nan")},
+    ),
+)
+def test_parse_session_response_invalid(response_json: object) -> None:
+    with pytest.raises(AuthError):
+        parse_session_response(response_json)

--- a/tests/prism/flashlight/test_account.py
+++ b/tests/prism/flashlight/test_account.py
@@ -7,11 +7,15 @@ from prism.flashlight.account import (
 )
 from prism.player import Account
 from prism.requests import make_prism_requests_session
+from tests.prism.auth_utils import make_real_clock_auth_manager
 
 
 def test_make_account_provider() -> None:
     provider = FlashlightAccountProvider(
-        retry_limit=3, initial_timeout=1.0, session=make_prism_requests_session()
+        retry_limit=3,
+        initial_timeout=1.0,
+        session=make_prism_requests_session(),
+        auth=make_real_clock_auth_manager(),
     )
     assert provider.seconds_until_unblocked == 0.0
 

--- a/tests/prism/flashlight/test_tags.py
+++ b/tests/prism/flashlight/test_tags.py
@@ -8,11 +8,15 @@ from prism.flashlight.tags import (
 )
 from prism.player import Tags, TagSeverity
 from prism.requests import make_prism_requests_session
+from tests.prism.auth_utils import make_real_clock_auth_manager
 
 
 def test_make_tags_provider() -> None:
     provider = FlashlightTagsProvider(
-        retry_limit=3, initial_timeout=1.0, session=make_prism_requests_session()
+        retry_limit=3,
+        initial_timeout=1.0,
+        session=make_prism_requests_session(),
+        auth=make_real_clock_auth_manager(),
     )
     assert provider.seconds_until_unblocked == 0.0
 

--- a/tests/prism/test_strange.py
+++ b/tests/prism/test_strange.py
@@ -1,6 +1,7 @@
 from prism.player import MISSING_WINSTREAKS
 from prism.requests import make_prism_requests_session
 from prism.strange import STATS_ENDPOINT, StrangePlayerProvider
+from tests.prism.auth_utils import make_real_clock_auth_manager
 from tests.prism.overlay.utils import make_winstreaks
 
 assert MISSING_WINSTREAKS == make_winstreaks()
@@ -20,5 +21,6 @@ def test_strange_player_provider() -> None:
         initial_timeout=1.0,
         get_time_ns=lambda: 1234567890123456789,
         session=make_prism_requests_session(),
+        auth=make_real_clock_auth_manager(),
     )
     assert provider.seconds_until_unblocked == 0.0


### PR DESCRIPTION
Prism logs in to flashlight and sends a server-issued bearer on every request, so
the per-user rate budget keys on an identity flashlight verified instead of a
self-asserted `X-User-Id` header.

Anonymous tier only. The server side is **already deployed and passive** — a
request with no `Authorization` header takes the old path — so nothing here is
visible to anyone until a release ships. Note what a release costs: it spends the
last two freedoms in the design (`/v1/auth/` route layout, and the Azure app
registration shape), and it makes the `auth_sessions` table-size check due.

Supersedes the old `anonymous-auth` branch (`7f9b451`, `b10621f`), which predates
proof-of-work and cannot log in against deployed flashlight. That branch should be
deleted rather than merged.

## The two commits

1. **`feat(auth): parse flashlight auth sessions and solve proof-of-work`** — the
   pure halves, with no callers, reviewable against the server contract on their
   own: the `Session` parser, the hash puzzle, and the error hierarchy.
2. **`feat(auth): send a server-issued bearer on every flashlight request`** — the
   auth thread, the transport, and the four call sites.

`Session` deliberately holds the server's **duration**, not a deadline —
`AuthManager` is the only thing that owns a clock, so there is exactly one in the
whole flow.

## Shape

```
flashlight/auth/session.py        Session value object + response parser   (pure)
flashlight/auth/proof_of_work.py  the hash puzzle                          (pure)
flashlight/auth/endpoints.py      challenge / login / refresh              (I/O)
flashlight/auth/anonymous.py      AnonymousLogin -> LoginMethod
flashlight/auth/manager.py        AuthManager: owns the session and the thread
flashlight/auth/request.py        send_authenticated: bearer, hint, 401 retry
```

`LoginMethod` is the one tier-specific seam — a `Protocol` with `tier` and
`log_in() -> Session`. Everything else is tier-blind: refresh branches on the
stored session server-side, the manager only ever holds a `Session`, and
`send_authenticated` never learns which tier issued the bearer. Adding the
Microsoft tier later is a second implementation plus a way to choose between
them, and nothing else in prism moves.

## Four decisions worth knowing before changing this

- **Every request carries a bearer, or it does not go out.** No unauthenticated
  fallback in the client: `wait_for_session` blocks up to 10s, then the request
  fails with `NoSessionError` (an `APIError`, so every call site already handles
  it). Disabling auth is a *server-side* operation — stub the login response and
  accept anything in the middleware — which needs no client logic and no client
  release. That matters because prism's upgrade tail is months long.
- **One writer.** Every login and refresh happens on a single daemon auth thread,
  so single-flight is structural rather than a lock protocol to get right.
  `stats_thread_count` is up to 16, so a lobby fan-out is ~16 concurrent bearer
  requests that all 401 together when a session lapses.
- **10s is the wait everywhere.** It has to be bounded because `set_nickname` →
  `controller.get_uuid` makes a flashlight request on the **tkinter thread**,
  where a longer wait is a frozen window.
- **One backoff curve, retried forever** — 2s doubling to a 5 minute cap with
  jitter, for every cause including the unfixable ones (a difficulty above our
  ceiling, an algorithm we don't implement). Retrying those every five minutes
  costs nothing and means dialling the server back down recovers every running
  overlay on its own, with no restart.

## Invariants that are easy to break by accident

Reviewers: these four are the ones worth checking, because each was a real bug
before it was an invariant.

- **The "reconcile requested" flag is cleared at the *end* of a pass.** A request
  reporting mid-pass has already been served by that pass, which read the very
  session being reported about. Clearing at the start leaks the flag past the end
  and the auth thread reconciles again immediately — and this is not a rare race:
  flashlight sets `X-Auth-Refresh` from exactly the point `refreshInSeconds`
  counts down to, i.e. exactly when our own timer fires, so in a lobby a stats
  response reports the hint during **every** proactive refresh. The redundant
  refresh it provoked was one the server refuses as too soon.
- **A too-soon refusal never schedules earlier than what was already scheduled.**
  The session is good until its own refresh point, and the server's minimum
  interval (30 min) is longer than the too-soon delay (5 min), so moving the
  attempt forward walked into the same refusal ~6 times — each pushing the request
  hold-off out again, which disables the reactive 401 path that is meant to be the
  guarantee.
- **A 401 report may not bypass the backoff.** Otherwise 16 stats threads each
  queue a login attempt while auth is broken. Same for a bug in `reconcile`: it
  sets a retry deadline, because the auth thread sleeps unexpected errors off and
  requests would otherwise keep blocking for the full wait on a pass that cannot
  come.
- **A token we have learnt is dead is dropped before the re-login is attempted**,
  so a login that also fails doesn't leave every request handing flashlight a
  bearer it has already rejected. Validating an unknown bearer costs the server an
  uncached `SELECT … FOR UPDATE`.

## The 401 on `/v1/tags`, and why a verdict is not a nullable session

`/v1/tags/{uuid}` answers **401 both for an invalid Urchin API key and for a
session flashlight won't accept**, indistinguishably. Handing back any surviving
401 for the call site to interpret is *not* good enough: `APIKeyError` latches
`urchin_api_key_invalid` for the rest of the process and cannot be cleared — once
set, the key is passed as `None`, so the reset branch that requires a key is
unreachable. One misattributed 401 costs the user a permanent "Invalid Urchin API
key" banner and a good key that stops being sent.

So `recover_from_unauthorized` returns a verdict:

| Outcome | What the caller does |
|---|---|
| a session | retry the request with it |
| no session, **server vouched** for ours (a too-soon 429) | return the 401 — it is the caller's to interpret |
| no session, no verdict (backoff, timed-out wait, failed re-login) | raise `SessionRecoveryError` |

Only the middle row reaches the tags call site as a 401. When the key really is
bad, the pass refreshes a perfectly good session and gets a 429 — which is exactly
the signal that makes the attribution safe. One wasted refresh per overlay run.

A structured error server-side would remove the ambiguity, and **has to be
additive once this ships**: released clients key `APIKeyError` off the bare 401,
so changing tags' 401 → 403 alone would make old prisms stop latching the flag,
keep sending the bad key, and keep failing every tags request for the rest of the
tail.

## Two things that used to depend on nothing

- **Notices are retried.** The notice thread runs once per launch and it is how
  users learn a new version exists, so a single failure — including the session not
  being established within the 10s wait — would otherwise mean no notices at all
  until a restart. `get_flashlight_notices` now distinguishes "failed" from
  "nothing to show".
- **`prism.stats` starts the auth thread from `main()`**, not at import. Importing
  a module should not spawn a thread that does network I/O and proof-of-work.

## Verification

Against `flashlight-test`, end to end: challenge → solve at difficulty 0 →
solution accepted → session issued (`flsess_`, tier `anonymous`, `canRefresh`
true) → bearer accepted on a data endpoint (200) → an immediate refresh correctly
refused as too-soon → an unknown bearer 401s.

Locally: 1433 tests pass, **100% coverage** (the repo gate), and
black / isort / flake8 / `mypy --strict` clean. The state machine is tested
directly — `reconcile()` driven by hand with a frozen clock, a fake `LoginMethod`
and a fake refresh — while the three HTTP calls and the thread's loop are
`# pragma: nocover`, like every other network path in prism.

One trap for the next test author: **the frozen test clock must never be made to
wait.** The wait loops recompute the remaining timeout from the clock, so a clock
that never advances never reaches the deadline. Use
`make_fast_forward_auth_manager()` or `running_auth_thread()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
