### PR TITLE
fix(overlay): rate the stars column by its own sort order

### DIFF
--- a/src/prism/overlay/output/cell_renderer.py
+++ b/src/prism/overlay/output/cell_renderer.py
@@ -434,7 +434,7 @@ def render_stats(
             rating_configs.stars.decimals,
             rating_configs.stars.levels,
             use_star_colors=not rating_configs.stars.rate_by_level,
-            sort_ascending=rating_configs.index.sort_ascending,
+            sort_ascending=rating_configs.stars.sort_ascending,
         )
         index_cell = render_based_on_level(
             truncate_float_or_int(player.stats.index, rating_configs.index.decimals),

--- a/src/prism/overlay/output/config.py
+++ b/src/prism/overlay/output/config.py
@@ -15,6 +15,21 @@ class RatingConfigDict(TypedDict):
     sort_ascending: bool
 
 
+def default_levels_for_sort_order(
+    default: "RatingConfig", sort_ascending: bool
+) -> tuple[float, ...]:
+    """
+    Return the default levels, ordered to match the given sort order
+
+    Levels are stored from worst to best, so they are listed in increasing order
+    when sorting descending, and in decreasing order when sorting ascending.
+    """
+    if sort_ascending == default.sort_ascending:
+        return default.levels
+
+    return tuple(reversed(default.levels))
+
+
 def read_rating_config_dict(
     source: Mapping[str, object], default: "RatingConfig"
 ) -> tuple[RatingConfigDict, bool]:
@@ -29,13 +44,6 @@ def read_rating_config_dict(
         rate_by_level = default.rate_by_level
         source_updated = True
 
-    levels = source.get("levels", None)
-    if not isinstance(levels, (list, tuple)) or not all(
-        isinstance(el, float) for el in levels
-    ):
-        levels = default.levels
-        source_updated = True
-
     decimals = source.get("decimals", None)
     if not isinstance(decimals, int) or decimals < 0:
         decimals = default.decimals
@@ -44,6 +52,14 @@ def read_rating_config_dict(
     sort_ascending = source.get("sort_ascending", None)
     if not isinstance(sort_ascending, bool):
         sort_ascending = default.sort_ascending
+        source_updated = True
+
+    levels = source.get("levels", None)
+    if not isinstance(levels, (list, tuple)) or not all(
+        isinstance(el, float) for el in levels
+    ):
+        # NOTE: Read after sort_ascending so the defaults can match the sort order
+        levels = default_levels_for_sort_order(default, sort_ascending)
         source_updated = True
 
     return {

--- a/src/prism/overlay/output/overlay/settings_page.py
+++ b/src/prism/overlay/output/overlay/settings_page.py
@@ -31,6 +31,7 @@ from prism.overlay.output.config import (
     DEFAULT_WLR_CONFIG,
     RatingConfig,
     RatingConfigCollection,
+    default_levels_for_sort_order,
 )
 from prism.overlay.output.overlay.gui_components import (
     KeybindSelector,
@@ -1196,13 +1197,15 @@ class RatingConfigEditor:  # pragma: nocover
 
         self._set_component_state()
 
-    def _get_levels(self) -> tuple[float, ...]:
+    def _get_levels(self, sort_ascending: bool) -> tuple[float, ...]:
         """Get the levels from the entries. Fallback to the default."""
         valid_characters = frozenset(string.digits + ".")
 
+        default_levels = default_levels_for_sort_order(self.default, sort_ascending)
+
         levels: list[float] = []
         for level_entry_variable, default_level in zip(
-            self.level_entry_variables, self.default.levels, strict=True
+            self.level_entry_variables, default_levels, strict=True
         ):
             value = level_entry_variable.get()
             clean_value = "".join(
@@ -1236,11 +1239,13 @@ class RatingConfigEditor:  # pragma: nocover
             )
             decimals = self.default.decimals
 
+        sort_ascending = not self.sort_descending_toggle.enabled
+
         return RatingConfig(
             self.rate_by_level_toggle.enabled,
-            self._get_levels(),
+            self._get_levels(sort_ascending),
             decimals,
-            not self.sort_descending_toggle.enabled,
+            sort_ascending,
         )
 
 

--- a/tests/prism/overlay/output/test_cell_renderer.py
+++ b/tests/prism/overlay/output/test_cell_renderer.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from collections.abc import Sequence
-from dataclasses import replace
+from dataclasses import fields, replace
 
 import pytest
 
@@ -654,3 +654,56 @@ def test_render_stats_stars_uses_stars_sort_ascending(
     stars_cell = render_stats(make_player(stars=stars), rating_configs).stars
 
     assert stars_cell.color_sections[0].color == gui_color
+
+
+RATING_COLUMNS = tuple(field.name for field in fields(RatingConfigCollection))
+
+UNIFORM_CONFIG = RatingConfig(
+    rate_by_level=True, levels=(1.0, 2.0, 3.0, 4.0), decimals=2, sort_ascending=False
+)
+UNIFORM_RATING_CONFIGS = RatingConfigCollection(
+    **{column: UNIFORM_CONFIG for column in RATING_COLUMNS}
+)
+
+# A player scoring above every level in UNIFORM_CONFIG for all stats, so that
+# flipping the sort order changes the rating of any column it applies to
+HIGH_STAT_PLAYER = make_player(
+    stars=1500,
+    fkdr=100,
+    kdr=100,
+    bblr=100,
+    wlr=100,
+    winstreak=1000,
+    kills=1_000_000,
+    finals=1_000_000,
+    beds=1_000_000,
+    wins=1_000_000,
+    lastLoginMs=1234567890 - 3_600_000,
+    lastLogoutMs=1234567890 - 7_200_000,
+)
+
+
+@pytest.mark.parametrize("column", RATING_COLUMNS)
+def test_render_stats_reads_the_config_of_each_column(column: str) -> None:
+    """Each rendered cell must depend on its own rating config, and no other"""
+    rating_configs = replace(
+        UNIFORM_RATING_CONFIGS,
+        **{
+            column: replace(
+                UNIFORM_CONFIG,
+                sort_ascending=True,
+                levels=tuple(reversed(UNIFORM_CONFIG.levels)),
+            )
+        },
+    )
+
+    before = render_stats(HIGH_STAT_PLAYER, UNIFORM_RATING_CONFIGS)
+    after = render_stats(HIGH_STAT_PLAYER, rating_configs)
+
+    changed = {
+        field.name
+        for field in fields(before)
+        if getattr(before, field.name) != getattr(after, field.name)
+    }
+
+    assert changed == {column}, f"Flipping the sort order of {column} changed {changed}"

--- a/tests/prism/overlay/output/test_cell_renderer.py
+++ b/tests/prism/overlay/output/test_cell_renderer.py
@@ -11,6 +11,7 @@ from prism.overlay.output.cell_renderer import (
     rate_value_descending,
     render_based_on_level,
     render_stars,
+    render_stats,
 )
 from prism.overlay.output.cells import (
     ALL_COLUMN_NAMES_ORDERED,
@@ -20,7 +21,24 @@ from prism.overlay.output.cells import (
     ColumnName,
 )
 from prism.overlay.output.color import MinecraftColor
+from prism.overlay.output.config import (
+    DEFAULT_BBLR_CONFIG,
+    DEFAULT_BEDS_CONFIG,
+    DEFAULT_FINALS_CONFIG,
+    DEFAULT_FKDR_CONFIG,
+    DEFAULT_INDEX_CONFIG,
+    DEFAULT_KDR_CONFIG,
+    DEFAULT_KILLS_CONFIG,
+    DEFAULT_SESSIONTIME_CONFIG,
+    DEFAULT_STARS_CONFIG,
+    DEFAULT_WINS_CONFIG,
+    DEFAULT_WINSTREAK_CONFIG,
+    DEFAULT_WLR_CONFIG,
+    RatingConfig,
+    RatingConfigCollection,
+)
 from prism.utils import truncate_float
+from tests.prism.overlay.utils import make_player
 
 LEVELS = (0.1, 0.5, 1, 10, 100)
 
@@ -573,3 +591,66 @@ def test_render_based_on_level_too_many_levels() -> None:
     assert render_based_on_level(
         "a", 100, (1, 2, 3, 4, 5, 6, 7, 8), True, sort_ascending=False
     ) == CellValue.monochrome("a", GUI_COLORS[4])
+
+
+DEFAULT_RATING_CONFIGS = RatingConfigCollection(
+    stars=DEFAULT_STARS_CONFIG,
+    index=DEFAULT_INDEX_CONFIG,
+    fkdr=DEFAULT_FKDR_CONFIG,
+    kdr=DEFAULT_KDR_CONFIG,
+    bblr=DEFAULT_BBLR_CONFIG,
+    wlr=DEFAULT_WLR_CONFIG,
+    winstreak=DEFAULT_WINSTREAK_CONFIG,
+    kills=DEFAULT_KILLS_CONFIG,
+    finals=DEFAULT_FINALS_CONFIG,
+    beds=DEFAULT_BEDS_CONFIG,
+    wins=DEFAULT_WINS_CONFIG,
+    sessiontime=DEFAULT_SESSIONTIME_CONFIG,
+)
+
+# Levels are stored in descending order when sorting ascending
+STARS_ASCENDING_CONFIG = RatingConfig(
+    rate_by_level=True,
+    levels=(800.0, 500.0, 300.0, 100.0),
+    decimals=2,
+    sort_ascending=True,
+)
+STARS_DESCENDING_CONFIG = RatingConfig(
+    rate_by_level=True,
+    levels=(100.0, 300.0, 500.0, 800.0),
+    decimals=2,
+    sort_ascending=False,
+)
+
+
+@pytest.mark.parametrize(
+    "stars_config, index_sort_ascending, stars, gui_color",
+    (
+        # Sorting ascending -> low stars rated highly
+        (STARS_ASCENDING_CONFIG, False, 50, GUI_COLORS[4]),
+        (STARS_ASCENDING_CONFIG, False, 1500, GUI_COLORS[0]),
+        (STARS_ASCENDING_CONFIG, True, 50, GUI_COLORS[4]),
+        (STARS_ASCENDING_CONFIG, True, 1500, GUI_COLORS[0]),
+        # Sorting descending -> high stars rated highly
+        (STARS_DESCENDING_CONFIG, False, 50, GUI_COLORS[0]),
+        (STARS_DESCENDING_CONFIG, False, 1500, GUI_COLORS[4]),
+        (STARS_DESCENDING_CONFIG, True, 50, GUI_COLORS[0]),
+        (STARS_DESCENDING_CONFIG, True, 1500, GUI_COLORS[4]),
+    ),
+)
+def test_render_stats_stars_uses_stars_sort_ascending(
+    stars_config: RatingConfig,
+    index_sort_ascending: bool,
+    stars: float,
+    gui_color: str,
+) -> None:
+    """The stars cell must be rated by the stars config, not the index config"""
+    rating_configs = replace(
+        DEFAULT_RATING_CONFIGS,
+        stars=stars_config,
+        index=replace(DEFAULT_INDEX_CONFIG, sort_ascending=index_sort_ascending),
+    )
+
+    stars_cell = render_stats(make_player(stars=stars), rating_configs).stars
+
+    assert stars_cell.color_sections[0].color == gui_color

--- a/tests/prism/overlay/output/test_config.py
+++ b/tests/prism/overlay/output/test_config.py
@@ -7,6 +7,7 @@ from prism.overlay.output.config import (
     RatingConfigCollection,
     RatingConfigCollectionDict,
     RatingConfigDict,
+    default_levels_for_sort_order,
     read_rating_config_collection_dict,
     read_rating_config_dict,
     safe_read_rating_config_collection_dict,
@@ -95,6 +96,7 @@ def test_read_rating_config_collection_dict(
 
 
 DEFAULT_LEVELS = (1.0, 2.0, 3.0, 4.0)
+REVERSED_DEFAULT_LEVELS = (4.0, 3.0, 2.0, 1.0)
 DEFAULT_DECIMALS = 2
 DEFAULT_RATE_BY_LEVEL = True
 DEFAULT_SORT_ASCENDING = True
@@ -169,14 +171,37 @@ READ_RATING_CONFIG_CASES: tuple[tuple[Mapping[str, object], RatingConfigDict], .
             "sort_ascending": DEFAULT_SORT_ASCENDING,
         },
     ),
+    # The default levels are flipped to match the requested sort order
     (
         {"sort_ascending": False},
         {
             "type": "level_based",
             "rate_by_level": DEFAULT_RATE_BY_LEVEL,
-            "levels": DEFAULT_LEVELS,
+            "levels": REVERSED_DEFAULT_LEVELS,
             "decimals": DEFAULT_DECIMALS,
             "sort_ascending": False,
+        },
+    ),
+    # Invalid levels + a differing sort order -> flipped default levels
+    (
+        {"sort_ascending": False, "levels": "garbage"},
+        {
+            "type": "level_based",
+            "rate_by_level": DEFAULT_RATE_BY_LEVEL,
+            "levels": REVERSED_DEFAULT_LEVELS,
+            "decimals": DEFAULT_DECIMALS,
+            "sort_ascending": False,
+        },
+    ),
+    # Invalid levels + the same sort order -> the default levels as they are
+    (
+        {"sort_ascending": True, "levels": "garbage"},
+        {
+            "type": "level_based",
+            "rate_by_level": DEFAULT_RATE_BY_LEVEL,
+            "levels": DEFAULT_LEVELS,
+            "decimals": DEFAULT_DECIMALS,
+            "sort_ascending": True,
         },
     ),
     (
@@ -263,3 +288,27 @@ def test_read_rating_config_dict(
     result, source_updated = reader(source, DEFAULT_CONFIG)
     assert result == target
     assert source_updated == (source != target)
+
+
+DESCENDING_DEFAULT_CONFIG = RatingConfig(
+    rate_by_level=DEFAULT_RATE_BY_LEVEL,
+    levels=DEFAULT_LEVELS,
+    decimals=DEFAULT_DECIMALS,
+    sort_ascending=False,
+)
+
+
+@pytest.mark.parametrize(
+    "default, sort_ascending, target",
+    (
+        (DEFAULT_CONFIG, True, DEFAULT_LEVELS),
+        (DEFAULT_CONFIG, False, REVERSED_DEFAULT_LEVELS),
+        (DESCENDING_DEFAULT_CONFIG, False, DEFAULT_LEVELS),
+        (DESCENDING_DEFAULT_CONFIG, True, REVERSED_DEFAULT_LEVELS),
+    ),
+)
+def test_default_levels_for_sort_order(
+    default: RatingConfig, sort_ascending: bool, target: tuple[float, ...]
+) -> None:
+    """The default levels must be flipped when the sort order differs"""
+    assert default_levels_for_sort_order(default, sort_ascending) == target


### PR DESCRIPTION
Selecting "Ascending" sort order for the stars column had no effect on its colors: with "rate by level" enabled, low-star players were still rated gray and high-star players dark red.

`render_stats` built the stars cell with the **index** column's sort order:

```python
stars_cell = render_stars(
    ...,
    sort_ascending=rating_configs.index.sort_ascending,   # should be .stars
)
```

So the stars column ignored its own sort order, and flipping the sort order of the index column silently flipped the star colors instead. Sorting the rows was never affected — that path already used the stars config.

While checking whether any other column was cross-wired the same way (none were), one related problem turned up. Levels are stored from worst to best, so they run in the opposite direction when sorting ascending — the settings GUI flips the entries when you toggle the sort order. But both fallback paths handed out the levels of the default config as they are, regardless of the sort order in use:

- `read_rating_config_dict`, when the settings file has no levels, or levels that don't parse
- `RatingConfigEditor._get_levels`, when a level entry in the settings GUI is empty or unparseable

In ascending mode either one yields an out of order tuple, which collapses the ratings to two colors. Both now go through `default_levels_for_sort_order`.

`DEFAULT_SESSIONTIME_CONFIG`'s levels `(10.0, 10.0, 10.0, 5.0)` reach only three of the five colors. That is intended, and is left alone.

## Testing

- `test_render_stats_stars_uses_stars_sort_ascending` covers the stars column under both sort orders, crossed with both index sort orders. It fails on the old code with `assert 'gray60' == 'red'`.
- `test_render_stats_reads_the_config_of_each_column` is the general form: it flips the sort order of one column at a time and asserts that exactly that column's cell changes. On the old code it fails for `stars` and `index` only, which is how the other ten columns were cleared.
- `test_default_levels_for_sort_order` covers the new helper, and the `read_rating_config_dict` cases cover the settings-file fallback. The GUI fallback shares the helper but is not covered by tests.

Full suite: 1374 passed, 2 skipped. `mypy --strict`, black, isort and flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
