### PR TITLE
fix: Correct and/or precedence in the playerdata retry guard, and four missing f prefixes

### DIFF
--- a/src/prism/overlay/nick_database.py
+++ b/src/prism/overlay/nick_database.py
@@ -89,7 +89,7 @@ class NickDatabase:
             if nick in database:
                 return database[nick]
 
-        raise ValueError("{nick} is not known by the database")
+        raise ValueError(f"{nick} is not known by the database")
 
     def __getitem__(self, nick: str) -> str:
         """Implement `nick_database[nick]` with `nick_database.denick(nick)`"""

--- a/src/prism/overlay/parsing.py
+++ b/src/prism/overlay/parsing.py
@@ -203,7 +203,7 @@ def words_match(words: Sequence[str], target: str) -> bool:
     )
 
     if not full_match:
-        logger.debug("Message does not match target! {joined_words=} != {target=}")
+        logger.debug(f"Message does not match target! {joined_words=} != {target=}")
 
     return full_match
 

--- a/src/prism/overlay/process_event.py
+++ b/src/prism/overlay/process_event.py
@@ -37,7 +37,7 @@ def process_event(
         logger.info(f"Setting new nickname {event.nick}={state.own_username}")
         if state.own_username is None:
             logger.warning(
-                "Own username is not set, could not add denick entry for {event.nick}."
+                f"Own username is not set, could not add denick entry for {event.nick}."
             )
             return state, False
 

--- a/src/prism/strange.py
+++ b/src/prism/strange.py
@@ -187,7 +187,7 @@ class StrangePlayerProvider:
             )
 
         if is_checked_too_many_offline_players_response(response):
-            raise APIError("Checked too many offline players for {uuid}")
+            raise APIError(f"Checked too many offline players for {uuid}")
 
         if response.status_code == 404:
             raise PlayerNotFoundError(f"Could not find a user with {uuid=} (404)")

--- a/src/prism/strange.py
+++ b/src/prism/strange.py
@@ -138,7 +138,9 @@ class StrangePlayerProvider:
                 f"Checked too many offline players for {url}, retrying"
             )
 
-        if response.status_code == 429 or response.status_code == 504 and not last_try:
+        if (
+            response.status_code == 429 or response.status_code == 504
+        ) and not last_try:
             raise ExecutionError(
                 "Request to AntiSniper API failed due to ratelimit, retrying"
             )


### PR DESCRIPTION
Two independent fixes, one commit each. Both are cases of code that is silently
wrong rather than broken — nothing raises, so neither showed up in tests or logs
as an error.

## 1. `and`/`or` precedence in the playerdata retry guard

`src/prism/strange.py`:

```python
if response.status_code == 429 or response.status_code == 504 and not last_try:
```

`and` binds tighter than `or`, so this parses as `(429) or ((504) and (not last_try))`
— the `not last_try` guard only ever applied to 504. Introduced in 3428efe
("fix: Retry on 504 from hypixel"), which added the `or` clause to an existing
`429 and not last_try` without parenthesising.

**Effect:** a 429 raises `ExecutionError` on every attempt including the last, so
`execute_with_retry` always exhausts and `get_player` converts it to a generic
`APIError`. The response object is discarded, which makes the
`response.status_code == 429` check further down in `get_player` unreachable —
`APIThrottleError` is never raised for a rate limit.

Today both paths end in `ERROR_DURING_PROCESSING`, so this is a **diagnosability
fix, not a behavioural one**: a real rate limit is logged via `logger.error` as an
unspecified API error rather than via `logger.warning` as a throttle, and without
the response body. Retry counts and network behaviour are unchanged — the request
is already sent before the raise-versus-return decision.

The value in fixing it is that the unreachable branch is a trap for any future
change that gives `APIThrottleError` distinct handling (a rate-limit notice,
backing off the client-side limiter). Worth noting the client limiter is
`limit=120, window=60` against a server token bucket of refill 2/s, burst 120 —
the same sustained rate, no headroom — plus two IP limiters ahead of it, so 429 is
reachable in practice, not hypothetical.

The parenthesised form used here matches the equivalent guards already correct in
`flashlight/account.py` and `flashlight/tags.py`.

## 2. Four missing `f` prefixes

String literals with `{...}` placeholders but no `f`, so they render braces
literally:

| File | Literal |
|---|---|
| `overlay/nick_database.py` | `ValueError("{nick} is not known by the database")` |
| `overlay/parsing.py` | `logger.debug("... {joined_words=} != {target=}")` |
| `overlay/process_event.py` | `logger.warning("... denick entry for {event.nick}.")` |
| `strange.py` | `APIError("Checked too many offline players for {uuid}")` |

All referenced names were already in scope, so this is purely the prefix. No test
asserted on any of these strings. `process_event.py` is the clearest case — the
`logger.info` immediately above it interpolates `event.nick` correctly, so the two
adjacent lines disagreed.

## Scope / how these were found

I swept all three repos for the precedence class with parser-exact checks (parens
recovered from source in Python, real AST nodes in Go and Babel), each validated
against positive and negative controls first:

| Repo | Scanned | Unparenthesized `and` inside `or` |
|---|---|---|
| prism (Python, `src` + `tests`) | all `.py` | **1** — fixed here |
| flashlight (Go) | 164 files | **0** |
| rainbow (TS/TSX) | 121 files | **0** |

Flashlight cross-checks two ways: the AST scan found nothing, and no line in the
repo contains both `&&` and `||`. So the precedence mistake is a genuine one-off.

## Deliberately left out

- **The `is_checked_too_many_offline_players_response` retry guard.** The same
  function raises `ExecutionError` for that response with *no* `last_try` guard at
  all, which strands the matching branch in `get_player` for the same structural
  reason. Left alone by request; commit 2 only fixes the `f` prefix on that line so
  the message is right if the branch is ever revived.
- **Removing the dead classification branches.** Flashlight's playerdata endpoint
  only returns 200/401/429/500/504 — never 403, and no flashlight response body
  contains "throttle" (the sole match across 164 Go files is the word "unthrottled",
  in a comment). So `is_invalid_api_key_response`, `is_global_throttle_response` and
  the too-many-offline check can none of them fire, making `APIKeyError` and
  `APIThrottleError` unreachable from `StrangePlayerProvider` — which means the
  `# TODO: Remove api key errors once we move to flashlight provider` in
  `controller.py` is already actionable. That is a behaviour change rather than a
  bug fix, so it belongs in its own PR.

## Testing

Both commits pass the full pre-commit suite (pyupgrade, black, isort, flake8,
mypy --strict, and the 100%-coverage gate) in a clean worktree venv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
