### PR TITLE
ci: use `uv sync --locked` in the test and build jobs

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --locked
 
       - name: Run typechecking
         run: |
@@ -122,7 +122,7 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: Install dependencies
         run: |
-          uv sync
+          uv sync --locked
 
           VERSION_STRING="$(uv run python -c 'from prism import VERSION_STRING; print(VERSION_STRING)')"
           echo "VERSION_STRING=$VERSION_STRING" >> $GITHUB_ENV


### PR DESCRIPTION
`uv sync` silently re-resolves dependencies when `uv.lock` is out of date with `pyproject.toml`. That means a PR touching dependencies without regenerating the lockfile goes green while CI installs a resolution the lockfile never described — the lockfile isn't actually gating anything.

`uv sync --locked` fails instead of re-resolving, which is the uv equivalent of the `--frozen-lockfile` we already use in rainbow.

Changed in `.github/workflows/testing.yml`:
- `test` job — `uv sync` → `uv sync --locked`
- `build` job — `uv sync` → `uv sync --locked`

`uv lock --check` passes on `main`, so this doesn't change what CI installs today; it just turns a silent re-resolve into a failure.

Left alone for now (they also run bare `uv sync`, but the two jobs above run on every push, so an unlocked change is already blocked): `linting.yml`, `check-tool-versions.yml`, `copilot-setup-steps.yml`. Happy to include them if you'd rather have it uniform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
