### PR TITLE
ci: Attest build provenance for release artifacts

### DIFF
--- a/.github/instructions/build.instructions.md
+++ b/.github/instructions/build.instructions.md
@@ -66,7 +66,19 @@ GitHub Actions (`.github/workflows/testing.yml`) automatically:
 3. **Quality checks**: Tests, type checking, linting
 4. **Icon generation**: Version overlay on icon
 5. **PyInstaller builds**: Platform-specific executables
-6. **Artifact upload**: Stores build results
+6. **Build provenance**: Signed SLSA attestation of the final artifact (`main` and tags only)
+7. **Artifact upload**: Stores build results
+
+### Build provenance
+The `build` job runs `actions/attest-build-provenance` on the finished artifact when
+building `main` or a tag. This requires `id-token: write` and `attestations: write` on
+the job, and lets users verify a download with
+`gh attestation verify <file> --repo Amund211/prism`.
+
+The attestation is bound to the artifact's SHA256 digest, so the attest step must stay
+the LAST step before the upload. Any step that rewrites the file — code signing,
+notarization, re-compression — must run *before* it, or verification will fail against
+the shipped file.
 
 ### Build Matrix
 - **OS**: ubuntu-latest, windows-latest, macOS-15

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -89,6 +89,12 @@ jobs:
 
   build:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      # Mint an OIDC token so Sigstore can bind the provenance to this workflow
+      id-token: write
+      # Write the resulting attestation to the repo's attestation store
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -178,6 +184,19 @@ jobs:
         if: matrix.OS_NAME != 'mac'
         run: |
           mv "dist/${{ env.SIMPLE_NAME }}${{ matrix.RESULT_EXTENSION }}" "${{ env.BUILD_RESULT_NAME }}"
+
+      # Publish SLSA build provenance for the artifact we hand to users, so they
+      # can verify it came out of this workflow at a known commit:
+      #   gh attestation verify <file> --repo Amund211/prism
+      # Only run for refs we cut releases from, to keep the attestation log
+      # meaningful. Keep this step LAST before the upload: the attestation is
+      # bound to the file's digest, so anything that rewrites the file
+      # (e.g. code signing) must happen before this runs.
+      - name: Attest build provenance
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: "${{ env.BUILD_RESULT_NAME }}"
 
       - name: Upload built binary/app .dmg
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/README.md
+++ b/README.md
@@ -140,6 +140,17 @@ The released binaries are created using `pyinstaller` in GitHub Actions from a c
 If you do not trust the released binary you can clone the project and run it from source by installing the dependencies and running `uv run prism_overlay.py` from the project root.
 See [running the overlay from source](#running-the-overlay-from-source) for more info.
 
+### Verifying your download
+Every released binary is published with [build provenance](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds), a signed statement of which repository, commit and workflow run produced the file.
+If you have the [GitHub CLI](https://cli.github.com/) installed you can check a downloaded file with:
+
+```bash
+gh attestation verify prism-v1.11.0-windows.exe --repo Amund211/prism
+```
+
+A successful run prints the commit and workflow that built the file.
+This proves the file came out of Prism's build pipeline unmodified — a binary someone else built, or one that has been tampered with after the build, will fail the check.
+
 ## Running the overlay from source
 Note: make sure you have a recent version of Python installed.
 The overlay currently depends on version `>=3.14`.


### PR DESCRIPTION
Run [`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance) on the finished binary/`.dmg` in the `build` job, so every artifact we cut a release from carries a signed [SLSA build provenance](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) statement of the repo, commit and workflow run that produced it.

Users can then check a download with:

```bash
gh attestation verify prism-v1.11.0-windows.exe --repo Amund211/prism
```

The attestation is keyed by the artifact's SHA256 digest, so downloading the artifact from a CI run and re-uploading it to a GitHub release does not break verification.

## What this is not

This is **not** code signing. SmartScreen, Defender and Gatekeeper know nothing about attestations, so the "unknown publisher" warning is unchanged. That still needs the Windows Trusted Signing work and macOS notarization.

What it does buy us:

- The README's Safety section claimed "built by GitHub Actions from a clean clone" — an unverifiable promise until now.
- A mechanical way to show that a reposted/trojaned `prism.exe` did not come from this repo.
- A check that the artifacts we publish to a release are the ones CI built from the release commit.

## Notes

- Gated to `main` and tags. Releases are always cut from a commit merged to `main`, and this keeps the attestation log free of per-branch noise.
- ⚠️ The attestation binds to the file's digest, so the attest step sits **last before the upload**. Any future step that rewrites the file — code signing, notarization, re-compression — must run *before* it, or the published binaries will fail verification while CI stays green. This is documented in the workflow comment and in `build.instructions.md`.
- `permissions` is set at job level (`id-token: write` for the OIDC token Sigstore binds the provenance to, `attestations: write` for the store), which means `contents: read` has to be repeated there since job-level grants replace the workflow-level one.
- Action pinned by commit SHA (v4.2.2) per the existing convention in this workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
