### PR TITLE
fix(overlay): return from --test-ssl before starting the auth thread

### DIFF
--- a/src/prism/overlay/__main__.py
+++ b/src/prism/overlay/__main__.py
@@ -81,6 +81,14 @@ def main() -> None:  # pragma: nocover
     from prism.requests import make_prism_requests_session
     from prism.strange import StrangePlayerProvider
 
+    # Below the imports so they stay covered, above auth.start() so we don't exit
+    # with its daemon thread mid-handshake inside OpenSSL.
+    if options.test_ssl:
+        from prism.overlay.testing import test_ssl
+
+        test_ssl()
+        return
+
     session = make_prism_requests_session()
 
     # Start authenticating right away, before the (possibly interactive) logfile
@@ -117,12 +125,6 @@ def main() -> None:  # pragma: nocover
         winstreak_provider=winstreak_provider,
         tags_provider=tags_provider,
     )
-
-    if options.test_ssl:
-        from prism.overlay.testing import test_ssl
-
-        test_ssl()
-        return
 
     if options.test:
         from prism.overlay.testing import get_test_loglines


### PR DESCRIPTION
Fixes the flaky `Test ssl system certs` job — e.g. [this run on #245](https://github.com/Amund211/prism/actions/runs/32274559384/job/96138790179?pr=245), which is unrelated to that PR.

## What failed

Nothing asserted by the step. Both checks printed exactly what they should:

```
Caught missing local issuer SSLError: ...   ← included-certs check OK
Got response: Hello world                   ← system-certs check OK
##[error]Process completed with exit code 139
```

`139 = 128 + 11` — SIGSEGV. The last `uv run prism_overlay.py --test-ssl` printed its expected output and then segfaulted during interpreter shutdown, ~2.5s later. `pipefail` turned that into a red job.

## Why

`main()` called `auth.start()` before it checked `options.test_ssl`:

```python
auth.start()          # daemon thread: /v1/auth/anonymous/challenge, PoW, /login
...
if options.test_ssl:
    test_ssl(); return    # ← returns with that thread mid-handshake
```

`AuthManager.start()` spawns `daemon=True`, so nothing joins it. `main()` returns immediately and CPython tears the interpreter down underneath a thread sitting inside OpenSSL/socket code.

This happens on **100% of `--test-ssl` runs** — the prism log for every invocation ends at

```
INFO ;prism.flashlight.auth.manager ;Logging in to flashlight (anonymous)
```

and never gets a follow-up line. Whether it actually segfaults depends on where the thread happens to be when finalization reaches it, which is why it's ~1-in-N rather than always. The 2.5s gap between the last print and the crash fits a Cloud Run cold start on flashlight: the response landed long after the main thread had gone.

Timeline is consistent — `auth.start()` landed 2026-08-08 in d361103, and this is the first exit-139 in the last 60 workflow runs.

## The fix

Return from `--test-ssl` immediately after the late imports, instead of after the session/auth/provider/controller construction that follows them.

The placement is the whole point of the change, so it is deliberately not moved any higher than it has to be:

- **below** the truststore injection and the late `prism.flashlight` / `prism.requests` imports, so the check still exercises all of them
- **above** `make_prism_requests_session()` and `auth.start()`, the first things that start a thread or talk to the network

The end-to-end proof is the `test` job itself: it asserts `grep '^Got response: Hello world'` for the system-certs invocation, which only passes if truststore really is resolving via the system store the local CA was installed into. Green on ubuntu, macOS and windows.

This also stops a hermetic localhost cert check from firing an anonymous login at the production backend on every CI run.

## Verification

In a scratch worktree, reproducing the CI step locally:

- 130 runs (65 included-certs + 65 system-certs) — all exit 0, expected output on every one
- no auth thread started at all now: `grep -l auth` across the last 10 prism logs returns 0
- `mypy --strict` clean, 1461 passed, 100% coverage, all pre-commit hooks green

I could not force the segfault locally in ~440 attempts (plain loops, single-CPU pinning, and a stand-in auth server sweeping its response delay across the shutdown window). The causal chain rests on the always-in-flight evidence above rather than on a reproduced crash.

## Not addressed here

The same teardown-during-handshake race is still reachable on the ordinary user path, and the tightest window is early startup rather than quit. `auth.start()` is immediately followed by `prompt_and_read_logfile`, and `get_logfile.py` exits the process from three places while the login is still open:

- `get_logfile.py:123` — user closes the logfile-selection window
- `get_logfile.py:308` — `ValueError` from `get_logfile`
- `get_logfile.py:312` — user selected no logfile

Launch prism with no `--logfile` and dismiss the dialog within the first second and you are in exactly the state that produced the 139 here. `AuthManager` has no `stop()` and nothing joins the thread. The ordinary quit path has it too — the close button calls `sys.exit(0)` with the auth thread plus up to 16 stats threads, all `daemon=True`, still live.

A user would see any of these as a rare crash-on-exit they'd never report. Fixing it means giving `AuthManager` a stop/join or short drain — a real change, worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
