### PR TITLE
feat(auth): attribute a 401 from flashlight's X-Auth-Session header

### DIFF
--- a/src/prism/flashlight/auth/errors.py
+++ b/src/prism/flashlight/auth/errors.py
@@ -46,7 +46,7 @@ class SessionRecoveryError(APIError):
     A request got a 401 we cannot account for
 
     The counterpart to handing a 401 back to the caller, which only happens when
-    the server has vouched for the session we hold. This says the opposite: we do
+    we know the session it carried was validated. This says the opposite: we do
     not know whose 401 it was, so a caller must not blame anything of its own for
     it. `/v1/tags/{uuid}` is why that distinction exists - it answers 401 for an
     invalid Urchin API key too, and wrongly latching that is sticky for the rest

--- a/src/prism/flashlight/auth/request.py
+++ b/src/prism/flashlight/auth/request.py
@@ -11,6 +11,11 @@ from prism.flashlight.auth.session import Session
 # thread, and ignoring it would still be correct.
 REFRESH_HINT_HEADER = "X-Auth-Refresh"
 
+# Set by flashlight's bearer middleware on every request it handled. `valid` means
+# it validated our bearer, so a 401 alongside it came from the handler.
+AUTH_SESSION_HEADER = "X-Auth-Session"
+AUTH_SESSION_VALID = "valid"
+
 # Performs one HTTP request, merging in the given auth headers.
 SendRequest = Callable[[Mapping[str, str]], requests.Response]
 
@@ -32,11 +37,16 @@ def send_authenticated(
     twice: prism holds one session for the whole process, so a lapsed session
     means the first call 401s and the second carries a renewed bearer.
 
-    A 401 is only ever returned to the caller when the server has vouched for the
-    session we hold, which means the 401 was about something else — that is what
-    lets `/v1/tags/{uuid}` interpret its own 401 for an invalid Urchin API key. A
-    401 we cannot account for raises `SessionRecoveryError` instead, so no call
-    site can mistake an auth problem for one of its own.
+    A 401 is only ever returned to the caller when we know the session we sent was
+    validated, which means the 401 was about something else — that is what lets
+    `/v1/tags/{uuid}` interpret its own 401 for an invalid Urchin API key. A 401 we
+    cannot account for raises `SessionRecoveryError` instead, so no call site can
+    mistake an auth problem for one of its own.
+
+    Normally the server says so on the 401 itself, in `X-Auth-Session`. Without it
+    we fall back to the auth manager, which can only confirm a session the server
+    refused to replace — so a lapsed session still recovers, but attribution is
+    given up on a 401 that survives a successful refresh.
 
     NOTE: `send` must be safe to call twice. Every flashlight endpoint prism
           calls is a read, so replaying one is harmless.
@@ -46,7 +56,9 @@ def send_authenticated(
         raise NoSessionError("No flashlight auth session available")
 
     response = send(bearer_headers(session))
-    if response.status_code != 401:
+    # Nothing here says our session is bad, so there is nothing to recover from -
+    # and the hint rides a validated 401 like any other response.
+    if response.status_code != 401 or _session_was_validated(response):
         _note_refresh_hint(auth, session, response)
         return response
 
@@ -61,19 +73,25 @@ def send_authenticated(
             "Got HTTP 401 from flashlight and could not renew the auth session"
         )
 
-    # TODO: The retry's own 401 is returned with no verdict at all, which breaks
-    #       the invariant this docstring promises and `tags.py` relies on. Same for
-    #       the session `recover_from_unauthorized` hands back from the
-    #       already-replaced branch: nothing has vouched for it. Concretely, during
-    #       a flashlight rollout or with read-replica lag the first request 401s,
-    #       the refresh succeeds against the primary, and the retry hits a replica
-    #       that has not seen the new session and 401s again - `tags.py` then
-    #       blames the Urchin API key and latches `urchin_api_key_invalid` for the
-    #       rest of the process. A second 401 should raise `SessionRecoveryError`
-    #       rather than reach the caller.
     response = send(bearer_headers(recovery.session))
+    if response.status_code == 401 and not _session_was_validated(response):
+        # A renewed bearer rejected with nothing confirming it is an auth problem,
+        # not the caller's: an instance that has not seen the new session - a
+        # rollout, or replica lag - looks exactly like a bad Urchin API key, and
+        # `tags.py` would latch `urchin_api_key_invalid` for the process.
+        raise SessionRecoveryError(
+            "Got HTTP 401 from flashlight with a renewed auth session"
+        )
     _note_refresh_hint(auth, recovery.session, response)
     return response
+
+
+def _session_was_validated(response: requests.Response) -> bool:
+    """Report whether the server says it validated the bearer we sent"""
+    # Exact match, unlike the permissive `_note_refresh_hint` below: a hint is safe
+    # to over-read, this is not. Absence means "unknown" - a stripped header, or
+    # something answering ahead of the middleware - which keeps recovery.
+    return response.headers.get(AUTH_SESSION_HEADER) == AUTH_SESSION_VALID
 
 
 def _note_refresh_hint(

--- a/src/prism/flashlight/notices.py
+++ b/src/prism/flashlight/notices.py
@@ -9,7 +9,7 @@ import requests
 from requests.exceptions import RequestException
 
 from prism import VERSION_STRING
-from prism.flashlight.auth.errors import NoSessionError
+from prism.flashlight.auth.errors import NoSessionError, SessionRecoveryError
 from prism.flashlight.auth.manager import AuthManager
 from prism.flashlight.auth.request import send_authenticated
 from prism.flashlight.headers import make_flashlight_client_headers
@@ -101,13 +101,11 @@ def _make_flashlight_notices_request(
     except NoSessionError:
         logger.warning("Skipping flashlight notices - no auth session yet")
         return None
-    # TODO: `SessionRecoveryError` is not caught here, and this endpoint is behind
-    #       the bearer middleware, so it does 401 on a dead session. The exception
-    #       propagates through `get_flashlight_notices` into
-    #       `NoticeCheckerThread.run`, which has no handler either - the thread dies
-    #       with an unhandled traceback, skipping the retries we just added, and the
-    #       user gets no notices at all (including the new-version prompt) until
-    #       restart.
+    except SessionRecoveryError:
+        # `NoticeCheckerThread.run` has no handler, so letting this out kills the
+        # thread and costs the user every notice until restart. `None` is retryable.
+        logger.warning("Skipping flashlight notices - got a 401 we cannot account for")
+        return None
 
     if not response.ok:
         logger.error(

--- a/tests/prism/flashlight/auth/test_auth_request.py
+++ b/tests/prism/flashlight/auth/test_auth_request.py
@@ -1,3 +1,4 @@
+import time
 from collections.abc import Mapping, Sequence
 
 import pytest
@@ -10,6 +11,8 @@ from prism.flashlight.auth.errors import (
     SessionRecoveryError,
 )
 from prism.flashlight.auth.request import (
+    AUTH_SESSION_HEADER,
+    AUTH_SESSION_VALID,
     REFRESH_HINT_HEADER,
     bearer_headers,
     send_authenticated,
@@ -24,12 +27,17 @@ from tests.prism.auth_utils import (
 
 
 def make_response(
-    status_code: int, *, refresh_hint: str | None = None
+    status_code: int,
+    *,
+    refresh_hint: str | None = None,
+    auth_session: str | None = None,
 ) -> requests.Response:
     response = requests.Response()
     response.status_code = status_code
     if refresh_hint is not None:
         response.headers[REFRESH_HINT_HEADER] = refresh_hint
+    if auth_session is not None:
+        response.headers[AUTH_SESSION_HEADER] = auth_session
     return response
 
 
@@ -109,6 +117,105 @@ def test_send_authenticated_surfaces_a_401_the_server_says_is_not_ours() -> None
 
     assert response.status_code == 401
     assert len(send.auth_headers) == 1
+
+
+def test_send_authenticated_returns_a_401_on_a_validated_session_immediately() -> None:
+    """
+    The server validated our session, so the 401 is the endpoint's
+
+    `refresh_results` is empty, so any attempt to renew fails the test.
+
+    NOTE: On the real clock, so a regression that runs recovery here times out
+          rather than hanging on a frozen clock that never reaches its deadline.
+    """
+    manager, _, refresh = make_auth_manager(
+        login_results=[make_session()], monotonic=time.monotonic
+    )
+    manager.reconcile()
+    before = manager.seconds_until_next_action()
+    send = RecordingSender([make_response(401, auth_session=AUTH_SESSION_VALID)])
+
+    response = send_authenticated(auth=manager, send=send)
+
+    assert response.status_code == 401
+    assert len(send.auth_headers) == 1
+    assert refresh.session_ids == []
+    # Nothing asked the auth thread for a pass either.
+    assert manager.seconds_until_next_action() == pytest.approx(before, abs=1.0)
+
+
+def test_send_authenticated_acts_on_the_refresh_hint_on_a_validated_401() -> None:
+    """The middleware sets both headers on the same response"""
+    session = make_session()
+    manager, _, _ = make_auth_manager(login_results=[session])
+    manager.reconcile()
+    assert manager.seconds_until_next_action() > 0
+
+    send_authenticated(
+        auth=manager,
+        send=RecordingSender(
+            [make_response(401, refresh_hint="1", auth_session=AUTH_SESSION_VALID)]
+        ),
+    )
+
+    assert manager.seconds_until_next_action() == 0.0
+
+
+def test_send_authenticated_ignores_an_unknown_auth_session_value() -> None:
+    """Only `valid` counts - any other value means the same as no header at all"""
+    session = make_session()
+    manager, _, refresh = make_auth_manager(
+        login_results=[session], refresh_results=[RefreshTooSoonError("too soon")]
+    )
+    manager.reconcile()
+    send = RecordingSender([make_response(401, auth_session="invalid")])
+
+    with running_auth_thread(manager):
+        response = send_authenticated(auth=manager, send=send)
+
+    assert response.status_code == 401
+    assert len(send.auth_headers) == 1
+    # The verdict came from the server refusing to refresh, i.e. the old path.
+    assert refresh.session_ids == [TEST_SESSION_ID]
+
+
+def test_send_authenticated_raises_when_the_retry_401s_unvalidated() -> None:
+    """
+    A renewed bearer that 401s with nothing confirming it is an auth problem
+
+    Handing that 401 to `tags.py` would latch `urchin_api_key_invalid`.
+    """
+    lapsed = make_session(session_id="flsess_lapsed")
+    renewed = make_session(session_id="flsess_renewed")
+    manager, _, _ = make_auth_manager(login_results=[lapsed], refresh_results=[renewed])
+    manager.reconcile()
+    send = RecordingSender([make_response(401), make_response(401)])
+
+    with running_auth_thread(manager):
+        with pytest.raises(SessionRecoveryError):
+            send_authenticated(auth=manager, send=send)
+
+    assert len(send.auth_headers) == 2
+
+
+def test_send_authenticated_returns_a_validated_401_from_the_retry() -> None:
+    """The renewed session is fine, so this 401 belongs to the caller"""
+    lapsed = make_session(session_id="flsess_lapsed")
+    renewed = make_session(session_id="flsess_renewed")
+    manager, _, _ = make_auth_manager(login_results=[lapsed], refresh_results=[renewed])
+    manager.reconcile()
+    send = RecordingSender(
+        [make_response(401), make_response(401, auth_session=AUTH_SESSION_VALID)]
+    )
+
+    with running_auth_thread(manager):
+        response = send_authenticated(auth=manager, send=send)
+
+    assert response.status_code == 401
+    assert send.auth_headers == [
+        {"Authorization": "Bearer flsess_lapsed"},
+        {"Authorization": "Bearer flsess_renewed"},
+    ]
 
 
 def test_send_authenticated_raises_on_a_401_it_cannot_account_for() -> None:


### PR DESCRIPTION
flashlight's bearer middleware now states what it decided about the bearer on
every response it handled ([flashlight#359](https://github.com/Amund211/flashlight/pull/359),
merged and deployed). `X-Auth-Session: valid` means our session was validated, so
a 401 alongside it came from the handler and is about something other than our
auth. This teaches prism to read it.

## What changes

**A first 401 that says the session was validated is returned to the caller
straight away** — no refresh, no wait, no round trip to hear that the session we
hold is fine. `/v1/tags/{uuid}` answers 401 for a bad Urchin API key as well as
for a bad session, and until now attributing the first kind cost a refresh
attempt (plus a WARNING when the server refused it as too soon). That was the
whole reason this header exists. The `X-Auth-Refresh` hint on that same response
is still honoured — the middleware sets both headers together, so a server-side
retune of refresh timing must not go unheard at a call site that 401s on every
player in every lobby.

**A retry whose 401 does *not* say so now raises `SessionRecoveryError`** instead
of reaching the caller. This closes the `TODO` that was sitting in `request.py`:
during a flashlight rollout, or with read-replica lag, the retry can land on an
instance that has not seen the session we just got — and `tags.py` would blame
the Urchin API key and latch `urchin_api_key_invalid` for the rest of the
process. The session `recover_from_unauthorized` hands back from its
already-replaced branch arrives on that path unconfirmed too, so it is covered by
the same check.

**`get_flashlight_notices` grows a handler for that error**, closing its own
`TODO`. It is the one call site that does not raise on to a caller handling
`APIError`, and `NoticeCheckerThread.run` has no handler either — so an uncaught
`SessionRecoveryError` would kill the thread and cost the user every notice,
including the new-version prompt, until restart. `None` is retryable, so the
thread's three attempts still apply.

## What deliberately does not change

- **Only the exact value `valid` counts.** That is the opposite of how
  `X-Auth-Refresh` is read ten lines away, where any non-empty value is honoured.
  A hint is safe to over-read; a statement we skip recovery on is not. Absence
  means "unknown" — a proxy stripping the header, something answering ahead of
  the middleware, a server rolled back to before the header existed.
- **The existing `recover_from_unauthorized` path is untouched.** Every unknown
  case still walks it and still gets the same three outcomes, so a server
  rollback or an old revision still *recovers* a lapsed session. It does give up
  on **attributing** a 401 that survives a successful refresh, which is the point
  above: on that path a lagging replica and a caller-side 401 look identical, and
  guessing wrong latches `urchin_api_key_invalid` for the process.
- No new logging, no new config, no change to any call site.

## Testing

New tests in `test_auth_request.py`: a validated 401 returns without touching the
manager (an empty refresh queue makes any renewal attempt fail the test), the
refresh hint on such a 401 is still acted on, an unknown header value walks the
old path, an unvalidated retry-401 raises, and a validated retry-401 is returned.
`coverage report` is at 100%, mypy clean. The notices handler sits in a
`# pragma: nocover` function, as the rest of that fetch path does.

Verification against production is the follow-up step: a bad Urchin key should
produce exactly one 401 at the tags call site, zero refreshes and no WARNING, and
a genuinely dead session must still recover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
