### PR TITLE
fix(auth): stop reading a 429 from refresh as a validated session

### DIFF
--- a/src/prism/flashlight/auth/endpoints.py
+++ b/src/prism/flashlight/auth/endpoints.py
@@ -7,7 +7,7 @@ from requests.exceptions import RequestException
 
 from prism.flashlight.auth.errors import (
     AuthError,
-    RefreshTooSoonError,
+    RefreshRateLimitedError,
     SessionExpiredError,
 )
 from prism.flashlight.auth.proof_of_work import Challenge, parse_challenge_response
@@ -121,8 +121,9 @@ def refresh_session(
     Extend the given session
 
     Tier-agnostic: the server branches on the stored session, so this is the
-    same call whichever `LoginMethod` established it. The session id does not
-    rotate - the returned session carries the same id with later deadlines.
+    same call whichever `LoginMethod` established it. The returned session
+    replaces the one we hold whole - the id is opaque, and whether it is the same
+    one is the server's business, not ours.
     """
     path = "/v1/auth/refresh"
     response = _post_json(
@@ -141,24 +142,10 @@ def refresh_session(
         )
 
     if response.status_code == 429:
-        # Either the too-soon throttle or the endpoint's IP rate limit. Both
-        # leave the session untouched, and re-logging in is the wrong reaction
-        # to both.
-        # TODO: The two causes are indistinguishable on the wire today, but they
-        #       do not mean the same thing, and we treat both as the server
-        #       vouching for our session: `_postpone` sets
-        #       `confirmed_session=True` and holds requests off for 5 minutes, so
-        #       every 401 in that window is handed back to the caller and
-        #       `tags.py` blames the Urchin API key - which latches
-        #       `urchin_api_key_invalid` permanently (once set, `urchin_api_key`
-        #       is passed as None, so the reset branch never runs). The IP limiter
-        #       runs before the handler and never looks at the bearer, so several
-        #       prism users behind one NAT/CGNAT IP can trip it while one of them
-        #       genuinely has a dead session: that user gets a permanent bogus
-        #       "Invalid Urchin API key" banner and stops sending a good key.
-        #       Only the too-soon throttle should confirm the session - needs the
-        #       server to tell the two apart.
-        raise RefreshTooSoonError("Flashlight refused to refresh this session yet")
+        # The endpoint's per-IP rate limit, and nothing else since the server
+        # dropped its minimum refresh interval. The limiters answer ahead of the
+        # handler that reads the bearer, so this says nothing about our session.
+        raise RefreshRateLimitedError("Flashlight rate limited the refresh request")
 
     if not response.ok:
         raise AuthError(f"Session refresh failed, status code {response.status_code}")

--- a/src/prism/flashlight/auth/errors.py
+++ b/src/prism/flashlight/auth/errors.py
@@ -22,13 +22,13 @@ class SessionExpiredError(AuthError):
     """
 
 
-class RefreshTooSoonError(AuthError):
+class RefreshRateLimitedError(AuthError):
     """
-    Flashlight refused to refresh a session it considers too fresh (429)
+    Flashlight rate limited the refresh request (429)
 
-    The opposite of `SessionExpiredError`: the session is untouched and still
-    good, so the session must be kept and re-login must NOT happen. Folding
-    this into the 401 case would turn a throttle into a re-login stampede.
+    Says nothing about the session, unlike `SessionExpiredError`: the per-IP
+    limiters answer ahead of the handler that reads the bearer. The session is
+    untouched, so keep it and do not re-log in.
     """
 
 
@@ -46,9 +46,9 @@ class SessionRecoveryError(APIError):
     A request got a 401 we cannot account for
 
     The counterpart to handing a 401 back to the caller, which only happens when
-    we know the session it carried was validated. This says the opposite: we do
-    not know whose 401 it was, so a caller must not blame anything of its own for
-    it. `/v1/tags/{uuid}` is why that distinction exists - it answers 401 for an
-    invalid Urchin API key too, and wrongly latching that is sticky for the rest
-    of the process.
+    the server told us it validated the bearer we sent (`X-Auth-Session`). This
+    says the opposite: we do not know whose 401 it was, so a caller must not
+    blame anything of its own for it. `/v1/tags/{uuid}` is why that distinction
+    exists - it answers 401 for an invalid Urchin API key too, and wrongly
+    latching that is sticky for the rest of the process.
     """

--- a/src/prism/flashlight/auth/manager.py
+++ b/src/prism/flashlight/auth/manager.py
@@ -3,12 +3,11 @@ import random
 import threading
 import time
 from collections.abc import Callable
-from dataclasses import dataclass
 from typing import Protocol
 
 from prism.flashlight.auth.errors import (
     AuthError,
-    RefreshTooSoonError,
+    RefreshRateLimitedError,
     SessionExpiredError,
 )
 from prism.flashlight.auth.session import Session
@@ -32,11 +31,9 @@ INITIAL_BACKOFF_SECONDS = 2.0
 MAX_BACKOFF_SECONDS = 300.0
 BACKOFF_MULTIPLIER = 2.0
 
-# How long to wait after the server says we refreshed too recently. No honest
-# client should ever see this - we refresh 55 minutes into a 1 hour session and
-# the server's floor is 30 minutes - so it is logged as the bug signal it is.
-# The session is untouched, so we keep using it.
-TOO_SOON_REFRESH_DELAY_SECONDS = 300.0
+# How long to wait after flashlight rate limited a refresh. The session is
+# untouched, so we keep using it and stop asking for a while.
+RATE_LIMITED_REFRESH_DELAY_SECONDS = 300.0
 
 
 class LoginMethod(Protocol):  # pragma: nocover
@@ -61,30 +58,6 @@ class LoginMethod(Protocol):  # pragma: nocover
 RefreshSession = Callable[[str], Session]
 
 
-@dataclass(frozen=True, slots=True)
-class Recovery:
-    """
-    What can be done about a request that got a 401
-
-    The two fields are not redundant, and the difference is what keeps a valid
-    Urchin API key from being blamed for an auth problem. `/v1/tags/{uuid}`
-    answers 401 both for a bad key and for a session flashlight won't accept, so
-    a caller may only interpret a 401 as its own when we can say the session is
-    not the cause.
-    """
-
-    # A session to retry the request with, if we got one. Note refresh does not
-    # rotate the id, so this can carry the same token with later deadlines.
-    session: Session | None
-
-    # True only when the *server* told us the session is fine - it refused to
-    # replace one it considers too fresh. Then the 401 was about something else,
-    # and the caller is the one that can interpret it. False whenever we could not
-    # get a verdict, which includes a failed re-login and a timed-out wait: a
-    # caller must not blame anything of its own for a 401 we cannot account for.
-    session_confirmed: bool
-
-
 def _default_jitter() -> float:  # pragma: nocover
     return random.uniform(0.75, 1.25)
 
@@ -106,8 +79,7 @@ class AuthManager:
 
     A `Session` is immutable and replaced wholesale, so "did anything change?" is
     an identity comparison, which is what the 401 path uses to tell "your session
-    was renewed, try again" from "your session is fine, that 401 was about
-    something else".
+    was renewed, try again" from "we have nothing for you".
     """
 
     def __init__(
@@ -140,9 +112,6 @@ class AuthManager:
         # thread's own backoff would otherwise be bypassed on every 401.
         self._retry_not_before = monotonic()
         self._reconcile_requested = False
-        # Whether the last pass ended with the server vouching for the session we
-        # hold. Read by recover_from_unauthorized - see `Recovery`.
-        self._last_pass_confirmed_session = False
         self._backoff_seconds = INITIAL_BACKOFF_SECONDS
         self._consecutive_failures = 0
         self._last_error: str | None = None
@@ -205,13 +174,13 @@ class AuthManager:
 
     def recover_from_unauthorized(
         self, observed: Session, timeout: float = SESSION_WAIT_TIMEOUT_SECONDS
-    ) -> "Recovery":
+    ) -> Session | None:
         """
-        Handle a 401 for `observed` and report what can be done about it
+        Handle a 401 for `observed` and return a session to retry it with
 
-        See `Recovery`: either there is a session to retry with, or the server has
-        confirmed the one we hold is fine (so the 401 was about something else), or
-        we simply do not know.
+        `None` means we have nothing to offer - a failed re-login, a timed-out
+        wait, a backoff - and is never a verdict on the 401. Only the server
+        gives one, on the 401 itself, in `X-Auth-Session`.
         """
         deadline = self._monotonic() + timeout
         with self._condition:
@@ -219,31 +188,28 @@ class AuthManager:
                 # Already replaced, by the auth thread's own timer or by another
                 # request's 401. Retry with what we have now - no server call.
                 # `None` here means it was replaced by nothing, i.e. discarded as
-                # dead, which is not a verdict on this 401.
+                # dead.
                 # TODO: Returning `None` here makes a fan-out of 401s fail outright
                 #       while the re-login it triggered is still in flight.
                 #       `self._session` is None for the whole login after `_discard`
                 #       (challenge + proof-of-work + login = two round trips), so
-                #       every other thread gets no session and no verdict and
-                #       raises `SessionRecoveryError` immediately. Concretely: a
-                #       laptop resumes from suspend - `time.monotonic()` does not
-                #       advance across suspend, so we still believe the session is
-                #       fresh while the server has expired it - the user opens a
-                #       lobby, up to 16 stats threads 401 together, and the whole
-                #       lobby renders as errors even though a valid session lands a
-                #       second later. `wait_for_session` would have waited; this
-                #       path does not. Fall through to the wait loop below when
+                #       every other thread gets nothing back and raises
+                #       `SessionRecoveryError` immediately. Concretely: a laptop
+                #       resumes from suspend - `time.monotonic()` does not advance
+                #       across suspend, so we still believe the session is fresh
+                #       while the server has expired it - the user opens a lobby, up
+                #       to 16 stats threads 401 together, and the whole lobby
+                #       renders as errors even though a valid session lands a second
+                #       later. `wait_for_session` would have waited; this path does
+                #       not. Fall through to the wait loop below when
                 #       `self._session is None`.
-                return Recovery(session=self._session, session_confirmed=False)
+                return self._session
 
             if self._monotonic() < self._retry_not_before:
-                # Auth is failing, or the server has just refused to touch this
-                # session. Either way: don't queue an attempt per request, and
-                # don't make the caller wait for one.
-                return Recovery(
-                    session=None,
-                    session_confirmed=self._last_pass_confirmed_session,
-                )
+                # Auth is failing, or flashlight has just rate limited us. Either
+                # way: don't queue an attempt per request, and don't make the
+                # caller wait for one.
+                return None
 
             target = self._passes + 1
             self._reconcile_requested = True
@@ -252,16 +218,12 @@ class AuthManager:
             while self._passes < target:
                 remaining = deadline - self._monotonic()
                 if remaining <= 0:
-                    # Timed out waiting for the pass, so we have no verdict.
-                    return Recovery(session=None, session_confirmed=False)
+                    # Timed out waiting for the pass, so we have nothing to offer.
+                    return None
                 self._condition.wait(remaining)
 
             current = self._session
-            if current is not observed:
-                return Recovery(session=current, session_confirmed=False)
-            return Recovery(
-                session=None, session_confirmed=self._last_pass_confirmed_session
-            )
+            return current if current is not observed else None
 
     def note_refresh_hint(self, session: Session) -> None:
         """
@@ -279,6 +241,9 @@ class AuthManager:
                 # Same reason as in recover_from_unauthorized: a fan-out of
                 # responses must not out-vote the auth thread's backoff.
                 return
+            # TODO: Unfloored, unlike the proactive timer. A server hinting on
+            #       every response gets one refresh per response wave forever -
+            #       the too-soon 429 used to bound that.
             self._reconcile_requested = True
             self._condition.notify_all()
 
@@ -315,15 +280,15 @@ class AuthManager:
 
         try:
             new_session = self._acquire(session)
-        except RefreshTooSoonError:
+        except RefreshRateLimitedError:
             # The session is untouched and still good. Keeping it is the whole
-            # point: reacting to this by logging in again would turn the
-            # server's throttle into the re-login stampede it exists to prevent.
+            # point: logging in again would throw away a session that works, and
+            # spend the login limiter to do it.
             logger.warning(
-                "Flashlight refused to refresh our session as too recent. "
-                "Keeping it and trying again later."
+                "Flashlight rate limited our session refresh. "
+                "Keeping the session we have and trying again later."
             )
-            self._postpone(TOO_SOON_REFRESH_DELAY_SECONDS)
+            self._postpone(RATE_LIMITED_REFRESH_DELAY_SECONDS)
         except AuthError as e:
             logger.warning("Failed establishing a flashlight auth session", exc_info=e)
             self._fail(str(e))
@@ -381,28 +346,28 @@ class AuthManager:
             self._backoff_seconds = INITIAL_BACKOFF_SECONDS
             self._consecutive_failures = 0
             self._last_error = None
-            self._finish_pass(confirmed_session=False)
+            self._finish_pass()
 
     def _postpone(self, delay: float) -> None:
         """
-        Nothing changed and nothing is wrong - come back later
+        Nothing changed - come back later
 
         **Never earlier than what was already scheduled.** The session we are
-        holding is good until its own refresh point, and a too-soon refusal says
-        nothing about that; moving the next attempt *forward* to `delay` would
-        walk into the same refusal again, and again, for as long as the server's
-        minimum interval has left to run.
+        holding is good until its own refresh point, and a rate limited refresh
+        says nothing about that; moving the next attempt *forward* to `delay`
+        would only spend more of the limit we have already hit.
 
-        Requests are held off for `delay` as well. The server has just told us it
-        will not touch this session, so asking again per 401 would only reproduce
-        the answer - and one of the two things that produce a 429 is the refresh
-        endpoint's own rate limit.
+        Requests are held off for `delay` too: asking again per 401 would only
+        reproduce the same rate limit.
         """
         with self._condition:
             retry_at = self._monotonic() + delay
             self._next_action_at = max(retry_at, self._next_action_at)
+            # TODO: This blocks the only path that can replace a session that
+            #       really is dead, and nothing logs in instead - login is a
+            #       different limiter and does not present the session.
             self._retry_not_before = retry_at
-            self._finish_pass(confirmed_session=True)
+            self._finish_pass()
 
     def _fail(self, error: str) -> None:
         with self._condition:
@@ -414,19 +379,18 @@ class AuthManager:
             )
             self._consecutive_failures += 1
             self._last_error = error
-            self._finish_pass(confirmed_session=False)
+            self._finish_pass()
 
-    def _finish_pass(self, *, confirmed_session: bool) -> None:
+    def _finish_pass(self) -> None:
         """Publish the outcome of a reconcile pass. Caller holds the condition."""
         # Cleared here, at the *end* of the pass. A request that reported a 401 or
         # a refresh hint while this pass was in flight has already been served by
         # it - the pass read the very session it is reporting about - so leaving
         # the flag set would make the auth thread immediately reconcile again.
-        # Right after a successful refresh that second pass is a refresh the
-        # server refuses as too soon, and every bearer response carries
-        # `X-Auth-Refresh` from exactly the moment our own timer fires, so a
-        # lobby fan-out sets the flag every single time.
+        # Right after a successful refresh that second pass renews what was just
+        # renewed, and every bearer response carries `X-Auth-Refresh` from exactly
+        # the moment our own timer fires, so a lobby fan-out sets the flag every
+        # single time.
         self._reconcile_requested = False
-        self._last_pass_confirmed_session = confirmed_session
         self._passes += 1
         self._condition.notify_all()

--- a/src/prism/flashlight/auth/request.py
+++ b/src/prism/flashlight/auth/request.py
@@ -37,16 +37,15 @@ def send_authenticated(
     twice: prism holds one session for the whole process, so a lapsed session
     means the first call 401s and the second carries a renewed bearer.
 
-    A 401 is only ever returned to the caller when we know the session we sent was
-    validated, which means the 401 was about something else — that is what lets
-    `/v1/tags/{uuid}` interpret its own 401 for an invalid Urchin API key. A 401 we
-    cannot account for raises `SessionRecoveryError` instead, so no call site can
-    mistake an auth problem for one of its own.
+    A 401 is only ever returned to the caller when the server says it validated
+    the session we sent (`X-Auth-Session: valid`), which means the 401 was about
+    something else — that is what lets `/v1/tags/{uuid}` interpret its own 401 for
+    an invalid Urchin API key. A 401 we cannot account for raises
+    `SessionRecoveryError` instead, so no call site can mistake an auth problem
+    for one of its own.
 
-    Normally the server says so on the 401 itself, in `X-Auth-Session`. Without it
-    we fall back to the auth manager, which can only confirm a session the server
-    refused to replace — so a lapsed session still recovers, but attribution is
-    given up on a 401 that survives a successful refresh.
+    That header is the only attribution mechanism: nothing the auth manager can
+    tell us amounts to "your session is fine".
 
     NOTE: `send` must be safe to call twice. Every flashlight endpoint prism
           calls is a read, so replaying one is harmless.
@@ -62,18 +61,13 @@ def send_authenticated(
         _note_refresh_hint(auth, session, response)
         return response
 
-    recovery = auth.recover_from_unauthorized(session)
-    if recovery.session is None:
-        if recovery.session_confirmed:
-            # The server refuses to replace this session, so it is fine and the
-            # 401 belongs to the caller. Sending the same bearer again would only
-            # reproduce it.
-            return response
+    renewed = auth.recover_from_unauthorized(session)
+    if renewed is None:
         raise SessionRecoveryError(
             "Got HTTP 401 from flashlight and could not renew the auth session"
         )
 
-    response = send(bearer_headers(recovery.session))
+    response = send(bearer_headers(renewed))
     if response.status_code == 401 and not _session_was_validated(response):
         # A renewed bearer rejected with nothing confirming it is an auth problem,
         # not the caller's: an instance that has not seen the new session - a
@@ -82,7 +76,7 @@ def send_authenticated(
         raise SessionRecoveryError(
             "Got HTTP 401 from flashlight with a renewed auth session"
         )
-    _note_refresh_hint(auth, recovery.session, response)
+    _note_refresh_hint(auth, renewed, response)
     return response
 
 

--- a/src/prism/flashlight/auth/session.py
+++ b/src/prism/flashlight/auth/session.py
@@ -5,11 +5,9 @@ from prism.flashlight.auth.errors import AuthError
 
 # The shortest delay we will ever schedule a proactive refresh for.
 #
-# The server decides when we refresh (`refreshInSeconds`, ~55 minutes into a
-# 1 hour session today) and we just obey it - but a bug or a misconfiguration
-# there must not be able to turn the auth thread into a hash-and-HTTP loop.
-# Refreshing a session the server considers too fresh changes nothing and comes
-# back 429, so a zero delay would spin.
+# `refreshInSeconds: 0` would otherwise spin: nothing refuses an early refresh,
+# so every pass succeeds and hands back another session asking for the same.
+# Floors the proactive timer only - see `note_refresh_hint`'s TODO.
 MIN_REFRESH_DELAY_SECONDS = 60.0
 
 

--- a/src/prism/flashlight/tags.py
+++ b/src/prism/flashlight/tags.py
@@ -66,9 +66,9 @@ class FlashlightTagsProvider:
 
         # NOTE: This endpoint answers 401 both for an invalid urchin API key and
         #       for an auth session flashlight won't accept. A 401 only reaches
-        #       this point when send_authenticated established that our session is
-        #       *not* the cause - otherwise it raises SessionRecoveryError - so
-        #       this one is the urchin key's. That distinction matters because
+        #       this point when the server itself told us it validated our session
+        #       (X-Auth-Session), so it is *not* the cause - any other 401 becomes
+        #       a SessionRecoveryError. That distinction matters because
         #       APIKeyError latches urchin_api_key_invalid for the rest of the
         #       process, which would stop us sending a perfectly good key.
         if response.status_code == 401:

--- a/tests/prism/flashlight/auth/test_auth_manager.py
+++ b/tests/prism/flashlight/auth/test_auth_manager.py
@@ -4,13 +4,13 @@ import pytest
 
 from prism.flashlight.auth.errors import (
     AuthError,
-    RefreshTooSoonError,
+    RefreshRateLimitedError,
     SessionExpiredError,
 )
 from prism.flashlight.auth.manager import (
     INITIAL_BACKOFF_SECONDS,
     MAX_BACKOFF_SECONDS,
-    TOO_SOON_REFRESH_DELAY_SECONDS,
+    RATE_LIMITED_REFRESH_DELAY_SECONDS,
 )
 from tests.prism.auth_utils import (
     make_auth_manager,
@@ -88,11 +88,11 @@ def test_reconcile_skips_a_refresh_that_would_be_pointless() -> None:
     assert refresh.session_ids == []
 
 
-def test_reconcile_keeps_the_session_when_a_refresh_is_too_soon() -> None:
-    """A 429 means the session is untouched - re-logging in would be a stampede"""
+def test_reconcile_keeps_the_session_when_a_refresh_is_rate_limited() -> None:
+    """A 429 leaves the session untouched, so keep it rather than log in again"""
     session = make_session(refresh_in_seconds=60.0)
     manager, login, refresh = make_auth_manager(
-        login_results=[session], refresh_results=[RefreshTooSoonError("too soon")]
+        login_results=[session], refresh_results=[RefreshRateLimitedError("slow down")]
     )
 
     manager.reconcile()
@@ -102,21 +102,20 @@ def test_reconcile_keeps_the_session_when_a_refresh_is_too_soon() -> None:
     assert login.calls == 1
     assert manager.consecutive_failures == 0
     assert manager.last_error is None
-    assert manager.seconds_until_next_action() == TOO_SOON_REFRESH_DELAY_SECONDS
+    assert manager.seconds_until_next_action() == RATE_LIMITED_REFRESH_DELAY_SECONDS
 
 
-def test_a_too_soon_refusal_never_schedules_earlier_than_the_session_wants() -> None:
+def test_a_rate_limited_refresh_never_schedules_earlier_than_wanted() -> None:
     """
     Otherwise one 429 becomes a loop of them
 
-    A session refused as too fresh is good until its own refresh point, and the
-    server's minimum interval is longer than the too-soon delay - so moving the
-    next attempt *forward* would just walk into the same refusal repeatedly, each
-    time logging a warning that claims no honest client sees it.
+    The session we hold is good until its own refresh point and the 429 says
+    nothing about it, so moving the next attempt *forward* would just spend the
+    endpoint's rate limit on an answer we already have.
     """
     session = make_session(refresh_in_seconds=3300.0)
     manager, login, refresh = make_auth_manager(
-        login_results=[session], refresh_results=[RefreshTooSoonError("too soon")]
+        login_results=[session], refresh_results=[RefreshRateLimitedError("slow down")]
     )
 
     manager.reconcile()
@@ -132,7 +131,7 @@ def test_a_request_arriving_mid_pass_does_not_provoke_a_second_one() -> None:
     Flashlight sets X-Auth-Refresh from the same point refreshInSeconds counts
     down to, so a lobby fan-out reports the hint while the refresh it asked for is
     still in flight. Leaving that request queued would make the auth thread
-    refresh again immediately - straight into a too-soon 429.
+    refresh again immediately - a round trip that renews what was just renewed.
     """
     session = make_session(session_id="flsess_first")
     refreshed = make_session(session_id="flsess_first")
@@ -169,9 +168,7 @@ def test_reconcile_records_a_bug_as_a_failure_before_re_raising() -> None:
     assert manager.consecutive_failures == 1
     assert manager.seconds_until_next_action() == INITIAL_BACKOFF_SECONDS
     # And a request that 401s now fails fast instead of waiting for a pass
-    recovery = manager.recover_from_unauthorized(session, timeout=5)
-    assert recovery.session is None
-    assert not recovery.session_confirmed
+    assert manager.recover_from_unauthorized(session, timeout=5) is None
 
 
 def test_reconcile_records_failures_and_backs_off() -> None:
@@ -245,39 +242,35 @@ def test_recover_from_unauthorized_adopts_a_session_someone_else_got() -> None:
 
     manager.reconcile()
 
-    recovery = manager.recover_from_unauthorized(stale, timeout=0)
-    assert recovery.session is current
-    assert not recovery.session_confirmed
+    assert manager.recover_from_unauthorized(stale, timeout=0) is current
     # Nothing was asked of the server
     assert login.calls == 1
     assert refresh.session_ids == []
 
 
-def test_recover_from_unauthorized_confirms_a_session_the_server_vouched_for() -> None:
+def test_recover_from_unauthorized_has_nothing_to_offer_after_a_429() -> None:
     """
-    A too-soon refusal is the server saying our session is fine
+    A rate limited refresh is not the server vouching for our session
 
-    Which is the only thing that lets /v1/tags conclude a 401 was its Urchin API
-    key's rather than ours.
+    The refresh endpoint's IP limiters answer ahead of the handler that reads the
+    bearer, so a 429 says nothing about the session we sent - and a caller told
+    otherwise blames its own 401 on an Urchin API key that is fine.
     """
     session = make_session()
     manager, login, refresh = make_auth_manager(
-        login_results=[session], refresh_results=[RefreshTooSoonError("too soon")]
+        login_results=[session], refresh_results=[RefreshRateLimitedError("slow down")]
     )
     manager.reconcile()
 
     with running_auth_thread(manager):
-        recovery = manager.recover_from_unauthorized(session, timeout=5)
-
-    assert recovery.session is None
-    assert recovery.session_confirmed
+        assert manager.recover_from_unauthorized(session, timeout=5) is None
 
 
-def test_recover_from_unauthorized_does_not_confirm_what_it_could_not_check() -> None:
+def test_recover_from_unauthorized_gives_up_while_auth_is_failing() -> None:
     """
     16 stats threads must not out-vote the auth thread's backoff
 
-    And while auth is failing we have no verdict on the session, so nothing may be
+    And while auth is failing we have nothing to retry with, so nothing may be
     told that its own 401 is explained.
     """
     session = make_session()
@@ -289,23 +282,19 @@ def test_recover_from_unauthorized_does_not_confirm_what_it_could_not_check() ->
     manager.reconcile()
     manager.reconcile()
 
-    recovery = manager.recover_from_unauthorized(session, timeout=0)
-    assert recovery.session is None
-    assert not recovery.session_confirmed
+    assert manager.recover_from_unauthorized(session, timeout=0) is None
     # No pass was requested, so the auth thread still gets to sleep off its backoff
     assert manager.seconds_until_next_action() == INITIAL_BACKOFF_SECONDS
 
 
-def test_recover_from_unauthorized_has_no_verdict_when_the_wait_times_out() -> None:
+def test_recover_from_unauthorized_has_nothing_when_the_wait_times_out() -> None:
     session = make_session()
     manager, login, refresh = make_auth_manager(login_results=[session])
 
     manager.reconcile()
 
     # No auth thread running, so the requested pass never completes
-    recovery = manager.recover_from_unauthorized(session, timeout=0)
-    assert recovery.session is None
-    assert not recovery.session_confirmed
+    assert manager.recover_from_unauthorized(session, timeout=0) is None
 
 
 def test_recover_from_unauthorized_waits_for_the_auth_thread() -> None:
@@ -320,10 +309,8 @@ def test_recover_from_unauthorized_waits_for_the_auth_thread() -> None:
     assert observed is session
 
     with running_auth_thread(manager):
-        recovery = manager.recover_from_unauthorized(observed, timeout=5)
+        assert manager.recover_from_unauthorized(observed, timeout=5) is renewed
 
-    assert recovery.session is renewed
-    assert not recovery.session_confirmed
     assert refresh.session_ids == ["flsess_lapsed"]
 
 

--- a/tests/prism/flashlight/auth/test_auth_request.py
+++ b/tests/prism/flashlight/auth/test_auth_request.py
@@ -7,7 +7,7 @@ import requests
 from prism.flashlight.auth.errors import (
     AuthError,
     NoSessionError,
-    RefreshTooSoonError,
+    RefreshRateLimitedError,
     SessionRecoveryError,
 )
 from prism.flashlight.auth.request import (
@@ -96,26 +96,25 @@ def test_send_authenticated_retries_once_with_a_renewed_session() -> None:
     ]
 
 
-def test_send_authenticated_surfaces_a_401_the_server_says_is_not_ours() -> None:
+def test_send_authenticated_raises_when_a_429_leaves_the_401_unexplained() -> None:
     """
-    /v1/tags answers 401 for an invalid Urchin API key too
+    A rate limited refresh is not a verdict on the session
 
-    Handing the 401 back is what lets that call site tell the two apart, and it
-    is also why the request is not retried with the same bearer. This is the real
-    shape of that case: the 401 provokes a refresh, the server refuses to touch a
-    session it considers too fresh, and so the 401 was never about the session.
+    The 429 comes from the endpoint's IP limiters, which answer ahead of the
+    handler that reads the bearer - so we still do not know whose 401 this was,
+    and handing it to `tags.py` would latch `urchin_api_key_invalid`.
     """
     session = make_session()
     manager, _, _ = make_auth_manager(
-        login_results=[session], refresh_results=[RefreshTooSoonError("too soon")]
+        login_results=[session], refresh_results=[RefreshRateLimitedError("slow down")]
     )
     manager.reconcile()
     send = RecordingSender([make_response(401)])
 
     with running_auth_thread(manager):
-        response = send_authenticated(auth=manager, send=send)
+        with pytest.raises(SessionRecoveryError):
+            send_authenticated(auth=manager, send=send)
 
-    assert response.status_code == 401
     assert len(send.auth_headers) == 1
 
 
@@ -163,20 +162,25 @@ def test_send_authenticated_acts_on_the_refresh_hint_on_a_validated_401() -> Non
 
 def test_send_authenticated_ignores_an_unknown_auth_session_value() -> None:
     """Only `valid` counts - any other value means the same as no header at all"""
-    session = make_session()
+    renewed = make_session(session_id="flsess_renewed")
     manager, _, refresh = make_auth_manager(
-        login_results=[session], refresh_results=[RefreshTooSoonError("too soon")]
+        login_results=[make_session()], refresh_results=[renewed]
     )
     manager.reconcile()
-    send = RecordingSender([make_response(401, auth_session="invalid")])
+    send = RecordingSender(
+        [make_response(401, auth_session="invalid"), make_response(200)]
+    )
 
     with running_auth_thread(manager):
         response = send_authenticated(auth=manager, send=send)
 
-    assert response.status_code == 401
-    assert len(send.auth_headers) == 1
-    # The verdict came from the server refusing to refresh, i.e. the old path.
+    assert response.status_code == 200
+    # The header was not trusted, so recovery ran and the request was retried
     assert refresh.session_ids == [TEST_SESSION_ID]
+    assert send.auth_headers == [
+        {"Authorization": f"Bearer {TEST_SESSION_ID}"},
+        {"Authorization": "Bearer flsess_renewed"},
+    ]
 
 
 def test_send_authenticated_raises_when_the_retry_401s_unvalidated() -> None:


### PR DESCRIPTION
`T19` of the stateless-session plan: **a 429 from `/v1/auth/refresh` no longer
means "the server vouched for my session"**, because since
[flashlight#383](https://github.com/Amund211/flashlight/pull/383) it cannot.

## Why

Flashlight dropped its minimum refresh interval, so the only thing left that
answers 429 on `/v1/auth/refresh` is the endpoint's per-IP rate limiter — and
those limiters run as middleware, ahead of the handler that reads the bearer.
The 429 says nothing about the session we sent.

We were reading it as a verdict. `_postpone` published
`confirmed_session=True`, `recover_from_unauthorized` handed that back for five
minutes, and `send_authenticated` returned any 401 in that window to the caller.
On `/v1/tags/{uuid}` that is `APIKeyError`, which latches
`urchin_api_key_invalid` for the rest of the process — once set, `urchin_api_key`
is passed as `None`, so the branch that would clear it is unreachable.

Concretely: several prism users behind one NAT/CGNAT IP trip the limiter while
one of them genuinely has a dead session. That user gets a permanent, bogus
"Invalid Urchin API key" banner and stops sending a perfectly good key.

## What changed

- **`X-Auth-Session: valid` is now the only attribution mechanism**, which is
  what [#256](https://github.com/Amund211/prism/pull/256) added it for. Nothing
  else can produce a "your session is fine" verdict any more, so `Recovery`
  collapses to the session it carried: `recover_from_unauthorized` returns
  `Session | None`, and a 401 the server did not mark as validated always
  becomes `SessionRecoveryError`.
- **A rate limited refresh still keeps the session and still holds requests off
  for five minutes.** It is the same 429 asking us to stop calling; it just no
  longer explains anyone's 401.
- **Renames, because neither name is about freshness any more:**
  `RefreshTooSoonError` → `RefreshRateLimitedError`,
  `TOO_SOON_REFRESH_DELAY_SECONDS` → `RATE_LIMITED_REFRESH_DELAY_SECONDS`.
- Comment-only fixes for facts the server changed: `refresh_session` no longer
  promises the id does not rotate (the stateless cutover rotates it, and the id
  is opaque to us either way), and `MIN_REFRESH_DELAY_SECONDS` explains the loop
  it prevents without citing a 429 that no longer happens — the floor still
  earns its keep, and more directly than before: a `refreshInSeconds: 0` bug now
  *succeeds* on every pass instead of being refused.

## Verification

`T19` also asked whether an immediate refresh still 429s. It does not — checked
against `flashlight-test` with prism's own auth code (challenge → solve → login
→ refresh → refresh), all 200, and prism treats the early refresh as an ordinary
one. The handle came back 50 chars and undotted, i.e. still row-backed: the
post-cutover re-run is the one box of `T19` this PR leaves open, since the
cutover has not landed.

`mypy --strict`, 100% coverage, black/isort/flake8 all clean.
