### PR TITLE
feat(auth): add a --test-pow proof-of-work benchmark

### DIFF
--- a/src/prism/flashlight/auth/benchmark.py
+++ b/src/prism/flashlight/auth/benchmark.py
@@ -1,0 +1,518 @@
+"""
+Benchmark the proof-of-work solver
+
+A calibration tool rather than part of the overlay: it answers what difficulty
+flashlight can ask a machine like this one for, given that the whole handshake
+has to fit inside a 60 second challenge TTL. Run it with `--test-pow`.
+
+Nothing here talks to flashlight. The challenges are minted locally, in the
+same shape the server mints them in.
+
+Everything timed is the shipped code: `solve_challenge` as the auth thread
+calls it, on a worker thread, at prod's constants, beside a running overlay.
+Nothing here may make the solve faster than a login does - a benchmark that
+outruns the real client reports a difficulty as affordable and hands users the
+sluggishness.
+"""
+
+import base64
+import json
+import logging
+import math
+import secrets
+import statistics
+import threading
+import time
+import uuid
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+
+from prism.flashlight.auth.proof_of_work import (
+    ALGORITHM_SHA256_LEADING_ZEROS,
+    MAX_DIFFICULTY,
+    Challenge,
+    solve_challenge,
+)
+
+logger = logging.getLogger(__name__)
+
+# flashlight's challengeTTL. It is measured from minting, so both round trips
+# and the solve come out of it - that, and not MAX_DIFFICULTY, is what caps the
+# difficulty that actually works.
+CHALLENGE_TTL_SECONDS = 60.0
+
+# The share of the TTL we let the solve spend. The rest pays for the two round
+# trips of the handshake.
+SOLVE_BUDGET_FRACTION = 0.5
+
+SOLVE_BUDGET_SECONDS = CHALLENGE_TTL_SECONDS * SOLVE_BUDGET_FRACTION
+
+# Solve time is geometric in the number of attempts, so a mean says little on
+# its own: the tail is what decides whether a difficulty is usable. For the
+# exponential it approximates, p95 is ln(20) means and p99 is ln(100).
+P95_FACTOR = math.log(20)
+P99_FACTOR = math.log(100)
+
+# What the wait costs the user, in seconds of p95 - the launch one user in
+# twenty gets, not the average one. The overlay has no session until the
+# handshake finishes, so this is dead time before the first stats can load.
+#
+# These are the numbers the whole benchmark exists to place a difficulty
+# against. They are judgement calls about perception, not measurements:
+# a second is under the threshold where a wait registers as a wait at all,
+# three is where one is clearly there but excusable at startup, and ten is
+# where a user starts wondering whether the overlay is broken.
+IMPERCEPTIBLE_UNTIL_SECONDS = 1.0
+NOTICEABLE_FROM_SECONDS = 3.0
+PAINFUL_FROM_SECONDS = 10.0
+
+# The band the estimate table covers. Below it the numbers are noise; above it
+# is over flashlight's own ceiling.
+ESTIMATE_FROM = 10
+
+DEFAULT_RUNS = 3
+
+VERDICT_IMPERCEPTIBLE = "imperceptible"
+VERDICT_FINE = "fine"
+VERDICT_NOTICEABLE = "noticeable"
+VERDICT_PAINFUL = "painful"
+VERDICT_EXPIRES = "unusable - the tail expires"
+VERDICT_NEVER = "does not converge"
+
+# Worst to best is the order that matters: a verdict is "at least as bad as"
+# another one.
+VERDICTS_IN_ORDER = (
+    VERDICT_IMPERCEPTIBLE,
+    VERDICT_FINE,
+    VERDICT_NOTICEABLE,
+    VERDICT_PAINFUL,
+    VERDICT_EXPIRES,
+    VERDICT_NEVER,
+)
+
+# The first verdict a user would actually feel. Everything from here up is the
+# answer to "where does this start to hurt".
+FIRST_HURTING_VERDICT = VERDICT_NOTICEABLE
+
+# The verdicts that are not a cost but a failure: the handshake does not
+# complete inside the TTL, so the client loops on challenges that expire.
+BROKEN_VERDICTS = (VERDICT_EXPIRES, VERDICT_NEVER)
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkSpec:
+    """What to measure: every difficulty in [first, last], `runs` times each"""
+
+    first: int
+    last: int
+    runs: int
+
+
+def parse_spec(spec: str) -> BenchmarkSpec:
+    """
+    Parse a `FIRST[-LAST][xRUNS]` spec, e.g. "20", "14-22", "18x10", "14-22x3"
+
+    Raises `ValueError` on anything else, including a difficulty above
+    MAX_DIFFICULTY - the solver refuses those, so benchmarking them is not a
+    thing we could do even if we wanted the number.
+    """
+    difficulties, times, runs_text = spec.partition("x")
+    first_text, dash, last_text = difficulties.partition("-")
+
+    try:
+        first = int(first_text)
+        # A trailing separator with nothing after it is a typo, not a default
+        last = int(last_text) if dash else first
+        runs = int(runs_text) if times else DEFAULT_RUNS
+    except ValueError as e:
+        raise ValueError(
+            f"Invalid proof-of-work benchmark spec {spec!r}. "
+            f"Expected FIRST[-LAST][xRUNS], e.g. 20, 14-22, 18x10, 14-22x3."
+        ) from e
+
+    if not 0 <= first <= last <= MAX_DIFFICULTY:
+        raise ValueError(
+            f"Invalid difficulty range {first}-{last} in benchmark spec {spec!r}. "
+            f"Must be rising and within 0-{MAX_DIFFICULTY}."
+        )
+
+    if runs < 1:
+        raise ValueError(f"Invalid run count {runs} in benchmark spec {spec!r}.")
+
+    return BenchmarkSpec(first=first, last=last, runs=runs)
+
+
+def _base64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode().rstrip("=")
+
+
+def mint_fake_challenge(difficulty: int) -> Challenge:
+    """
+    Mint a challenge shaped like flashlight's, solvable without the server
+
+    The shape matters for the measurement, not just for looks. Every attempt
+    hashes `challenge:solution`, so the ~320 characters of a real challenge
+    cost six SHA-256 blocks where a short stand-in would cost one - measuring
+    against a short stand-in would overstate the hash rate several times over.
+    """
+    payload = json.dumps(
+        {
+            "nonce": _base64url(secrets.token_bytes(16)),
+            "userId": str(uuid.uuid4()),
+            "ipHash": secrets.token_hex(32),
+            "issuedAtUnixMillis": int(time.time() * 1000),
+            "difficulty": difficulty,
+            "alg": ALGORITHM_SHA256_LEADING_ZEROS,
+        },
+        # Go's encoding/json emits no whitespace, and the length is the point
+        separators=(",", ":"),
+    ).encode()
+
+    return Challenge(
+        challenge=f"{_base64url(payload)}.{_base64url(secrets.token_bytes(32))}",
+        algorithm=ALGORITHM_SHA256_LEADING_ZEROS,
+        difficulty=difficulty,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class Run:
+    """One timed solve"""
+
+    difficulty: int
+    duration_seconds: float
+    hashes: int
+
+
+def time_one_solve(
+    difficulty: int, clock: Callable[[], float] = time.perf_counter
+) -> Run:
+    """
+    Solve one freshly minted fake challenge and time it
+
+    `time.perf_counter` rather than `time.monotonic`: the coarse clock on
+    Windows would report whole runs at the low difficulties as taking no time.
+    """
+    challenge = mint_fake_challenge(difficulty)
+
+    start = clock()
+    solution = solve_challenge(challenge)
+    duration_seconds = clock() - start
+
+    # The solver counts up from 0, so the winning counter is also the number of
+    # attempts that missed before it.
+    return Run(
+        difficulty=difficulty,
+        duration_seconds=duration_seconds,
+        hashes=int(solution) + 1,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class Summary:
+    """The runs at one difficulty, reduced to the numbers worth reporting"""
+
+    difficulty: int
+    runs: int
+    mean_seconds: float
+    median_seconds: float
+    min_seconds: float
+    max_seconds: float
+    mean_hashes: float
+    hashes_per_second: float
+
+
+def summarize(difficulty: int, runs: Sequence[Run]) -> Summary:
+    """Summarize a non-empty sequence of runs at one difficulty"""
+    durations = [run.duration_seconds for run in runs]
+    hashes = [run.hashes for run in runs]
+    total_seconds = sum(durations)
+
+    return Summary(
+        difficulty=difficulty,
+        runs=len(runs),
+        mean_seconds=statistics.fmean(durations),
+        median_seconds=statistics.median(durations),
+        min_seconds=min(durations),
+        max_seconds=max(durations),
+        mean_hashes=statistics.fmean(hashes),
+        # A whole run can measure as no time at all on a coarse clock, and an
+        # unmeasurably fast run is not an infinitely fast one.
+        hashes_per_second=(
+            sum(hashes) / total_seconds if total_seconds > 0 else math.nan
+        ),
+    )
+
+
+def verdict_for(mean_seconds: float, budget_seconds: float) -> str:
+    """
+    What a difficulty costs the user whose client does the work
+
+    Judged on p95, not on the mean. Solve time is geometric - anywhere from
+    instant to several times the mean - so what a user carries away is their
+    worst launches, and an average that looks fine hides them.
+    """
+    p95_seconds = mean_seconds * P95_FACTOR
+
+    # The failures first: past the budget it stops being a wait and starts
+    # being a handshake that cannot complete.
+    if mean_seconds > budget_seconds:
+        return VERDICT_NEVER
+    if p95_seconds > budget_seconds:
+        return VERDICT_EXPIRES
+
+    if p95_seconds > PAINFUL_FROM_SECONDS:
+        return VERDICT_PAINFUL
+    if p95_seconds > NOTICEABLE_FROM_SECONDS:
+        return VERDICT_NOTICEABLE
+    if p95_seconds > IMPERCEPTIBLE_UNTIL_SECONDS:
+        return VERDICT_FINE
+    return VERDICT_IMPERCEPTIBLE
+
+
+def hurts(verdict: str) -> bool:
+    """Whether a user would feel a wait this long"""
+    return VERDICTS_IN_ORDER.index(verdict) >= VERDICTS_IN_ORDER.index(
+        FIRST_HURTING_VERDICT
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class Estimate:
+    """What one difficulty would cost, extrapolated from a measured hash rate"""
+
+    difficulty: int
+    mean_hashes: int
+    mean_seconds: float
+    p95_seconds: float
+    p99_seconds: float
+    verdict: str
+
+
+def estimate_difficulties(
+    hashes_per_second: float, budget_seconds: float = SOLVE_BUDGET_SECONDS
+) -> list[Estimate]:
+    """Extrapolate the whole difficulty band from one measured hash rate"""
+    estimates = []
+    for difficulty in range(ESTIMATE_FROM, MAX_DIFFICULTY + 1):
+        mean_hashes = 2**difficulty
+        mean_seconds = mean_hashes / hashes_per_second
+        estimates.append(
+            Estimate(
+                difficulty=difficulty,
+                mean_hashes=mean_hashes,
+                mean_seconds=mean_seconds,
+                p95_seconds=mean_seconds * P95_FACTOR,
+                p99_seconds=mean_seconds * P99_FACTOR,
+                verdict=verdict_for(mean_seconds, budget_seconds),
+            )
+        )
+    return estimates
+
+
+def format_headline(estimates: Sequence[Estimate]) -> str:
+    """
+    Say where the difficulty starts to hurt
+
+    The one line the benchmark exists to produce. Everything else in the report
+    is the working behind it.
+    """
+    first_hurting = next(
+        (estimate for estimate in estimates if hurts(estimate.verdict)), None
+    )
+    last_working = next(
+        (
+            estimate
+            for estimate in reversed(estimates)
+            if estimate.verdict not in BROKEN_VERDICTS
+        ),
+        None,
+    )
+
+    if first_hurting is None:
+        top = estimates[-1]
+        return (
+            f"Nothing up to difficulty {top.difficulty} hurts on this machine - "
+            f"p95 is still {format_seconds(top.p95_seconds)} at the ceiling."
+        )
+
+    parts = [
+        f"Starts to hurt at difficulty {first_hurting.difficulty}: "
+        f"p95 {format_seconds(first_hurting.p95_seconds)} "
+        f"({first_hurting.verdict})."
+    ]
+
+    if first_hurting.difficulty > estimates[0].difficulty:
+        below = estimates[estimates.index(first_hurting) - 1]
+        parts.append(
+            f"Difficulty {below.difficulty} and under is free "
+            f"(p95 {format_seconds(below.p95_seconds)})."
+        )
+
+    if last_working is not None and last_working.difficulty >= first_hurting.difficulty:
+        parts.append(f"Stops working entirely above {last_working.difficulty}.")
+
+    return " ".join(parts)
+
+
+def format_seconds(seconds: float) -> str:
+    """Format a duration for the report"""
+    if seconds < 1:
+        return f"{seconds * 1000:.0f}ms"
+    return f"{seconds:.2f}s"
+
+
+def _row(cells: Sequence[str], widths: Sequence[int]) -> str:
+    return "  ".join(
+        cell.rjust(width) if index else cell.ljust(width)
+        for index, (cell, width) in enumerate(zip(cells, widths, strict=True))
+    )
+
+
+_SUMMARY_WIDTHS = (4, 4, 9, 9, 9, 9, 12, 11)
+_ESTIMATE_WIDTHS = (4, 12, 9, 9, 9, 28)
+
+
+def format_summaries(summaries: Sequence[Summary]) -> list[str]:
+    """Format the measured results as a table"""
+    lines = [
+        _row(
+            ("diff", "runs", "mean", "median", "min", "max", "hashes", "rate"),
+            _SUMMARY_WIDTHS,
+        )
+    ]
+    for summary in summaries:
+        lines.append(
+            _row(
+                (
+                    str(summary.difficulty),
+                    str(summary.runs),
+                    format_seconds(summary.mean_seconds),
+                    format_seconds(summary.median_seconds),
+                    format_seconds(summary.min_seconds),
+                    format_seconds(summary.max_seconds),
+                    f"{summary.mean_hashes:,.0f}",
+                    f"{summary.hashes_per_second / 1000:,.0f} kH/s",
+                ),
+                _SUMMARY_WIDTHS,
+            )
+        )
+    return lines
+
+
+def format_estimates(estimates: Sequence[Estimate]) -> list[str]:
+    """Format the extrapolated difficulty band as a table"""
+    lines = [
+        _row(("diff", "hashes", "mean", "p95", "p99", "verdict"), _ESTIMATE_WIDTHS)
+    ]
+    for estimate in estimates:
+        lines.append(
+            _row(
+                (
+                    str(estimate.difficulty),
+                    f"{estimate.mean_hashes:,}",
+                    format_seconds(estimate.mean_seconds),
+                    format_seconds(estimate.p95_seconds),
+                    format_seconds(estimate.p99_seconds),
+                    estimate.verdict,
+                ),
+                _ESTIMATE_WIDTHS,
+            )
+        )
+    return lines
+
+
+def format_report(
+    summaries: Sequence[Summary], budget_seconds: float = SOLVE_BUDGET_SECONDS
+) -> str:
+    """
+    Render the whole report
+
+    The estimates come off the hardest difficulty measured: those are the runs
+    where the hash loop, rather than the timing overhead, dominates.
+    """
+    if not summaries:
+        return "No proof-of-work results to report."
+
+    basis = summaries[-1]
+    estimates = estimate_difficulties(basis.hashes_per_second, budget_seconds)
+
+    return "\n".join(
+        (
+            "",
+            format_headline(estimates),
+            "",
+            "Measured",
+            *format_summaries(summaries),
+            "",
+            f"Estimated from {basis.hashes_per_second / 1000:,.0f} kH/s measured "
+            f"at difficulty {basis.difficulty} over {basis.runs} run(s). Solve "
+            f"time is geometric, so p95 is ~3x the mean and p99 ~4.6x. A verdict "
+            f"is how the p95 wait reads to a user; the last two mean the "
+            f"handshake no longer fits the "
+            f"{budget_seconds:.0f}s of flashlight's "
+            f"{CHALLENGE_TTL_SECONDS:.0f}s challenge TTL left for the solve.",
+            *format_estimates(estimates),
+        )
+    )
+
+
+def run_benchmark(spec: BenchmarkSpec, report: Callable[[str], None]) -> list[Summary]:
+    """
+    Measure every difficulty in the spec, reporting each run as it lands
+
+    Call it from a worker thread - see `start_benchmark`.
+
+    Deliberately unwarmed. A login solves exactly one challenge, cold, so a
+    warmup run would exclude a cost the user really pays and report a
+    difficulty as cheaper than it is.
+    """
+    summaries = []
+    for difficulty in range(spec.first, spec.last + 1):
+        runs = []
+        for index in range(spec.runs):
+            run = time_one_solve(difficulty)
+            runs.append(run)
+            report(
+                f"difficulty {difficulty} "
+                f"run {index + 1}/{spec.runs}: "
+                f"{format_seconds(run.duration_seconds)} "
+                f"({run.hashes:,} hashes)"
+            )
+        summaries.append(summarize(difficulty, runs))
+    return summaries
+
+
+def start_benchmark(
+    spec: BenchmarkSpec,
+    report: Callable[[str], None],
+    budget_seconds: float = SOLVE_BUDGET_SECONDS,
+) -> threading.Thread:
+    """
+    Start the benchmark on a background thread and return it, already running
+
+    Not joined, so the caller goes on to run the overlay: the point of running
+    both is that the hash loop competes for the GIL with the tkinter thread and
+    the stats threads, exactly as a real login's solve does.
+
+    A worker thread rather than the main one for the same reason.
+    `solve_challenge` is auth-thread-only in the overlay, and the thread is
+    what decides who the loop shares the interpreter with.
+
+    A daemon, so closing the overlay does not wait for a sweep to finish.
+    """
+
+    def target() -> None:
+        try:
+            summaries = run_benchmark(spec, report)
+        except BaseException:
+            # The benchmark is a diagnostic running beside the real overlay. It
+            # reports its own failure and leaves everything else alone.
+            logger.exception("The proof-of-work benchmark failed")
+            report("The proof-of-work benchmark failed - see the log for why.")
+            return
+        report(format_report(summaries, budget_seconds))
+
+    thread = threading.Thread(target=target, daemon=True, name="prism-pow-benchmark")
+    thread.start()
+    return thread

--- a/src/prism/overlay/__main__.py
+++ b/src/prism/overlay/__main__.py
@@ -89,6 +89,16 @@ def main() -> None:  # pragma: nocover
         test_ssl()
         return
 
+    # Parsed here, before the (possibly interactive) logfile selection, so a
+    # typo in the spec fails now rather than after a window is up.
+    pow_benchmark_spec = None
+    if options.test_pow is not None:
+        from prism.overlay.testing import parse_pow_benchmark_spec
+
+        pow_benchmark_spec = parse_pow_benchmark_spec(options.test_pow)
+        if pow_benchmark_spec is None:
+            return
+
     session = make_prism_requests_session()
 
     # Start authenticating right away, before the (possibly interactive) logfile
@@ -134,6 +144,14 @@ def main() -> None:  # pragma: nocover
         loglines = prompt_and_read_logfile(controller, options, settings)
 
     controller.ready = True
+
+    # Last, so the benchmark runs against a fully started overlay: auth up,
+    # stats threads live, and the tkinter mainloop about to take the main
+    # thread. That contention is the whole reason to run both.
+    if pow_benchmark_spec is not None:
+        from prism.overlay.testing import start_pow_benchmark
+
+        start_pow_benchmark(pow_benchmark_spec)
 
     run_overlay(controller, loglines, auth)
 

--- a/src/prism/overlay/commandline.py
+++ b/src/prism/overlay/commandline.py
@@ -5,6 +5,11 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
+# What `--test-pow` measures when given no spec of its own. Difficulty 22 is
+# the top of the band flashlight considers usable, and three runs is enough for
+# the hash rate - which converges far faster than the individual solve times.
+DEFAULT_POW_SPEC = "16-22x3"
+
 
 @dataclass
 class Options:
@@ -13,6 +18,8 @@ class Options:
     loglevel: int
     test_ssl: bool
     test: bool
+    # The proof-of-work benchmark spec, or None to not run the benchmark
+    test_pow: str | None = None
 
 
 def resolve_path(p: str) -> Path:  # pragma: no cover
@@ -70,6 +77,22 @@ def get_options(
         action="store_true",
     )
 
+    # Not suppressed like the other test flags: it is a calibration tool you
+    # are meant to be able to find and to pass parameters to.
+    parser.add_argument(
+        "--test-pow",
+        help=(
+            "Benchmark the proof-of-work solver beside the running overlay, "
+            "printing the results to stdout. Takes an optional "
+            f"FIRST[-LAST][xRUNS] spec, e.g. 20, 14-22, 18x10 "
+            f"(default {DEFAULT_POW_SPEC})"
+        ),
+        nargs="?",
+        const=DEFAULT_POW_SPEC,
+        default=None,
+        metavar="SPEC",
+    )
+
     # Parse the args
     # Parses from sys.argv if args is None
     parsed = parser.parse_args(args=args)
@@ -80,6 +103,7 @@ def get_options(
     assert isinstance(parsed.verbose, int)
     assert isinstance(parsed.test_ssl, bool)
     assert isinstance(parsed.test, bool)
+    assert parsed.test_pow is None or isinstance(parsed.test_pow, str)
 
     if parsed.verbose <= 0:
         # Default loglevel to INFO
@@ -101,4 +125,5 @@ def get_options(
         loglevel=loglevel,
         test_ssl=parsed.test_ssl,
         test=parsed.test,
+        test_pow=parsed.test_pow,
     )

--- a/src/prism/overlay/testing.py
+++ b/src/prism/overlay/testing.py
@@ -3,6 +3,7 @@
 import time
 from collections.abc import Iterable
 
+from prism.flashlight.auth.benchmark import BenchmarkSpec, parse_spec, start_benchmark
 from prism.overlay.commandline import Options
 from prism.ssl_errors import is_missing_local_issuer_error
 
@@ -44,6 +45,38 @@ def get_test_loglines(options: Options) -> Iterable[str]:  # pragma: nocover
         loglines = slow_iterable(loglines, wait=wait)
 
     return loglines
+
+
+def parse_pow_benchmark_spec(spec: str) -> BenchmarkSpec | None:  # pragma: nocover
+    """
+    Parse a `--test-pow` spec, printing why and returning None if it is invalid
+
+    Separate from starting the benchmark so a typo is caught before the overlay
+    starts, rather than after the logfile prompt and a window.
+    """
+    try:
+        return parse_spec(spec)
+    except ValueError as e:
+        print(e)
+        return None
+
+
+def start_pow_benchmark(spec: BenchmarkSpec) -> None:  # pragma: nocover
+    """
+    Start the proof-of-work benchmark beside the overlay that is about to run
+
+    Backgrounded on purpose: the overlay keeps starting, and the hash loop then
+    competes for the GIL with the tkinter thread and the stats threads, the way
+    a real login's solve does. Pass -q to keep the stats table out of the
+    output.
+    """
+    print(
+        f"Benchmarking the proof-of-work solver at difficulty "
+        f"{spec.first}-{spec.last}, {spec.runs} run(s) each, beside the running "
+        f"overlay. Solving fake challenges - nothing is sent to flashlight."
+    )
+
+    start_benchmark(spec, report=print)
 
 
 def test_ssl() -> None:  # pragma: nocover

--- a/tests/prism/flashlight/auth/test_auth_benchmark.py
+++ b/tests/prism/flashlight/auth/test_auth_benchmark.py
@@ -1,0 +1,411 @@
+import hashlib
+import itertools
+from collections.abc import Callable
+
+import pytest
+
+from prism.flashlight.auth.benchmark import (
+    DEFAULT_RUNS,
+    ESTIMATE_FROM,
+    IMPERCEPTIBLE_UNTIL_SECONDS,
+    NOTICEABLE_FROM_SECONDS,
+    P95_FACTOR,
+    P99_FACTOR,
+    PAINFUL_FROM_SECONDS,
+    VERDICT_EXPIRES,
+    VERDICT_FINE,
+    VERDICT_IMPERCEPTIBLE,
+    VERDICT_NEVER,
+    VERDICT_NOTICEABLE,
+    VERDICT_PAINFUL,
+    VERDICTS_IN_ORDER,
+    BenchmarkSpec,
+    Estimate,
+    Run,
+    estimate_difficulties,
+    format_headline,
+    format_report,
+    format_seconds,
+    hurts,
+    mint_fake_challenge,
+    parse_spec,
+    run_benchmark,
+    start_benchmark,
+    summarize,
+    time_one_solve,
+    verdict_for,
+)
+from prism.flashlight.auth.proof_of_work import (
+    ALGORITHM_SHA256_LEADING_ZEROS,
+    MAX_DIFFICULTY,
+    leading_zero_bits,
+    solve_challenge,
+)
+
+
+def make_clock(*times: float) -> Callable[[], float]:
+    """A clock returning the given readings, one per call"""
+    readings = iter(times)
+    return lambda: next(readings)
+
+
+@pytest.mark.parametrize(
+    "spec, result",
+    (
+        ("20", BenchmarkSpec(first=20, last=20, runs=DEFAULT_RUNS)),
+        ("0", BenchmarkSpec(first=0, last=0, runs=DEFAULT_RUNS)),
+        ("14-22", BenchmarkSpec(first=14, last=22, runs=DEFAULT_RUNS)),
+        ("18x10", BenchmarkSpec(first=18, last=18, runs=10)),
+        ("14-22x3", BenchmarkSpec(first=14, last=22, runs=3)),
+        # A one-wide range is still a range
+        ("18-18x1", BenchmarkSpec(first=18, last=18, runs=1)),
+        (
+            f"{MAX_DIFFICULTY}",
+            BenchmarkSpec(first=MAX_DIFFICULTY, last=MAX_DIFFICULTY, runs=DEFAULT_RUNS),
+        ),
+    ),
+)
+def test_parse_spec(spec: str, result: BenchmarkSpec) -> None:
+    assert parse_spec(spec) == result
+
+
+@pytest.mark.parametrize(
+    "spec",
+    (
+        "",
+        "x",
+        "x3",
+        "-",
+        "-20",
+        "abc",
+        "20x",
+        "20xabc",
+        "1.5",
+        "20 22",
+        # Falling range
+        "22-14",
+        # Negative
+        "20x-1",
+        "20x0",
+        # Above what the solver will work on
+        f"{MAX_DIFFICULTY + 1}",
+        f"20-{MAX_DIFFICULTY + 1}",
+    ),
+)
+def test_parse_spec_invalid(spec: str) -> None:
+    with pytest.raises(ValueError):
+        parse_spec(spec)
+
+
+def test_mint_fake_challenge() -> None:
+    challenge = mint_fake_challenge(4)
+
+    assert challenge.algorithm == ALGORITHM_SHA256_LEADING_ZEROS
+    assert challenge.difficulty == 4
+
+    # Shaped like flashlight's: a signed payload, a ".", and the signature
+    payload, separator, signature = challenge.challenge.partition(".")
+    assert separator == "."
+    assert payload and signature
+
+    # The length is the measurement - a real challenge spans several SHA-256
+    # blocks, and a short stand-in would hash several times faster.
+    assert 250 < len(challenge.challenge) < 400
+
+
+def test_mint_fake_challenge_is_unique() -> None:
+    """Two runs must not solve the same challenge"""
+    assert mint_fake_challenge(0) != mint_fake_challenge(0)
+
+
+def test_mint_fake_challenge_is_solvable() -> None:
+    challenge = mint_fake_challenge(8)
+    solution = solve_challenge(challenge)
+
+    digest = hashlib.sha256(f"{challenge.challenge}:{solution}".encode()).digest()
+    assert leading_zero_bits(digest) >= 8
+
+
+def test_time_one_solve() -> None:
+    run = time_one_solve(4, clock=make_clock(10.0, 12.5))
+
+    assert run.difficulty == 4
+    assert run.duration_seconds == 2.5
+    # Every attempt from 0 up to and including the winning one
+    assert run.hashes >= 1
+
+
+def test_time_one_solve_counts_every_attempt() -> None:
+    """Difficulty 0 is solved by the first counter value"""
+    run = time_one_solve(0, clock=make_clock(0.0, 1.0))
+
+    assert run.hashes == 1
+
+
+def make_run(duration_seconds: float, hashes: int, difficulty: int = 18) -> Run:
+    return Run(difficulty=difficulty, duration_seconds=duration_seconds, hashes=hashes)
+
+
+def test_summarize() -> None:
+    summary = summarize(
+        18, (make_run(1.0, 1000), make_run(3.0, 5000), make_run(2.0, 3000))
+    )
+
+    assert summary.difficulty == 18
+    assert summary.runs == 3
+    assert summary.mean_seconds == 2.0
+    assert summary.median_seconds == 2.0
+    assert summary.min_seconds == 1.0
+    assert summary.max_seconds == 3.0
+    assert summary.mean_hashes == 3000
+    assert summary.hashes_per_second == 9000 / 6.0
+
+
+def test_summarize_unmeasurably_fast_runs() -> None:
+    """A coarse clock reports no time at all, which is not infinite speed"""
+    summary = summarize(0, (make_run(0.0, 1, difficulty=0),))
+
+    assert summary.hashes_per_second != summary.hashes_per_second  # nan
+
+
+@pytest.mark.parametrize(
+    "mean_seconds, verdict",
+    (
+        # Judged on p95, which is ln(20) means
+        (0.0, VERDICT_IMPERCEPTIBLE),
+        (IMPERCEPTIBLE_UNTIL_SECONDS / P95_FACTOR, VERDICT_IMPERCEPTIBLE),
+        (0.4, VERDICT_FINE),
+        (NOTICEABLE_FROM_SECONDS / P95_FACTOR, VERDICT_FINE),
+        (1.1, VERDICT_NOTICEABLE),
+        (PAINFUL_FROM_SECONDS / P95_FACTOR, VERDICT_NOTICEABLE),
+        (4.0, VERDICT_PAINFUL),
+        # p95 past the budget: the handshake stops fitting the TTL
+        (30 / P95_FACTOR, VERDICT_PAINFUL),
+        (11.0, VERDICT_EXPIRES),
+        (30.0, VERDICT_EXPIRES),
+        # Not even the mean fits
+        (31.0, VERDICT_NEVER),
+        (600.0, VERDICT_NEVER),
+    ),
+)
+def test_verdict_for(mean_seconds: float, verdict: str) -> None:
+    assert verdict_for(mean_seconds, 30.0) == verdict
+
+
+def test_verdict_for_is_monotonic() -> None:
+    """More work is never a better verdict"""
+    verdicts = [verdict_for(mean_seconds / 10, 30.0) for mean_seconds in range(1, 500)]
+    indices = [VERDICTS_IN_ORDER.index(verdict) for verdict in verdicts]
+
+    assert indices == sorted(indices)
+    # And the whole scale is reachable
+    assert set(verdicts) == set(VERDICTS_IN_ORDER)
+
+
+@pytest.mark.parametrize(
+    "verdict, hurting",
+    (
+        (VERDICT_IMPERCEPTIBLE, False),
+        (VERDICT_FINE, False),
+        (VERDICT_NOTICEABLE, True),
+        (VERDICT_PAINFUL, True),
+        (VERDICT_EXPIRES, True),
+        (VERDICT_NEVER, True),
+    ),
+)
+def test_hurts(verdict: str, hurting: bool) -> None:
+    assert hurts(verdict) is hurting
+
+
+def test_estimate_difficulties() -> None:
+    estimates = estimate_difficulties(1_000_000, budget_seconds=30.0)
+
+    assert [estimate.difficulty for estimate in estimates] == list(
+        range(ESTIMATE_FROM, MAX_DIFFICULTY + 1)
+    )
+
+    # Each difficulty is twice the work of the one below it
+    for lower, higher in itertools.pairwise(estimates):
+        assert higher.mean_hashes == lower.mean_hashes * 2
+        assert higher.mean_seconds == pytest.approx(lower.mean_seconds * 2)
+
+    at_20 = estimates[20 - ESTIMATE_FROM]
+    assert at_20.mean_hashes == 2**20
+    assert at_20.mean_seconds == pytest.approx(1.048576)
+    assert at_20.p95_seconds == pytest.approx(1.048576 * P95_FACTOR)
+    assert at_20.p99_seconds == pytest.approx(1.048576 * P99_FACTOR)
+    # A p95 of ~3.1s at a million hashes a second
+    assert at_20.verdict == VERDICT_NOTICEABLE
+
+    # It only ever gets worse across the band
+    indices = [VERDICTS_IN_ORDER.index(estimate.verdict) for estimate in estimates]
+    assert indices == sorted(indices)
+    assert estimates[0].verdict == VERDICT_IMPERCEPTIBLE
+    assert estimates[-1].verdict == VERDICT_NEVER
+
+
+@pytest.mark.parametrize(
+    "seconds, formatted",
+    (
+        (0.0, "0ms"),
+        (0.0004, "0ms"),
+        (0.5, "500ms"),
+        (0.9999, "1000ms"),
+        (1.0, "1.00s"),
+        (12.345, "12.35s"),
+        (600.0, "600.00s"),
+    ),
+)
+def test_format_seconds(seconds: float, formatted: str) -> None:
+    assert format_seconds(seconds) == formatted
+
+
+def make_estimate(difficulty: int, verdict: str, p95_seconds: float = 1.0) -> Estimate:
+    return Estimate(
+        difficulty=difficulty,
+        mean_hashes=2**difficulty,
+        mean_seconds=p95_seconds / P95_FACTOR,
+        p95_seconds=p95_seconds,
+        p99_seconds=p95_seconds * P99_FACTOR / P95_FACTOR,
+        verdict=verdict,
+    )
+
+
+def test_format_headline() -> None:
+    headline = format_headline(
+        (
+            make_estimate(10, VERDICT_IMPERCEPTIBLE, 0.5),
+            make_estimate(11, VERDICT_FINE, 2.0),
+            make_estimate(12, VERDICT_NOTICEABLE, 4.0),
+            make_estimate(13, VERDICT_PAINFUL, 12.0),
+            make_estimate(14, VERDICT_EXPIRES, 40.0),
+        )
+    )
+
+    assert "Starts to hurt at difficulty 12" in headline
+    assert "4.00s" in headline
+    # The last one that is free, and the last one that works at all
+    assert "Difficulty 11 and under is free" in headline
+    assert "Stops working entirely above 13" in headline
+
+
+def test_format_headline_when_the_first_difficulty_already_hurts() -> None:
+    headline = format_headline(
+        (
+            make_estimate(10, VERDICT_PAINFUL, 12.0),
+            make_estimate(11, VERDICT_NEVER, 90.0),
+        )
+    )
+
+    assert "Starts to hurt at difficulty 10" in headline
+    assert "and under is free" not in headline
+    assert "Stops working entirely above 10" in headline
+
+
+def test_format_headline_when_nothing_hurts() -> None:
+    headline = format_headline(
+        (
+            make_estimate(10, VERDICT_IMPERCEPTIBLE, 0.1),
+            make_estimate(11, VERDICT_FINE, 2.0),
+        )
+    )
+
+    assert "Nothing up to difficulty 11 hurts" in headline
+    assert "2.00s" in headline
+
+
+def test_format_headline_when_everything_is_broken() -> None:
+    headline = format_headline((make_estimate(10, VERDICT_NEVER, 900.0),))
+
+    assert "Starts to hurt at difficulty 10" in headline
+    assert "Stops working" not in headline
+
+
+def test_format_report() -> None:
+    summaries = (
+        summarize(18, (make_run(1.0, 250_000),)),
+        summarize(19, (make_run(2.0, 500_000),)),
+    )
+
+    report = format_report(summaries, budget_seconds=30.0)
+
+    # The answer comes first, before the working behind it
+    assert report.strip().startswith("Starts to hurt at difficulty ")
+    assert "Measured" in report
+    # Both measured difficulties, and the whole estimated band
+    for difficulty in (18, 19, *range(ESTIMATE_FROM, MAX_DIFFICULTY + 1)):
+        assert f"\n{difficulty} " in report
+    # Estimates come off the hardest difficulty measured
+    assert "difficulty 19" in report
+    assert VERDICT_IMPERCEPTIBLE in report
+    assert VERDICT_NEVER in report
+
+
+def test_format_report_without_results() -> None:
+    assert format_report(()) == "No proof-of-work results to report."
+
+
+def collect(reports: list[str]) -> Callable[[str], None]:
+    return reports.append
+
+
+def test_run_benchmark() -> None:
+    reports: list[str] = []
+
+    summaries = run_benchmark(
+        BenchmarkSpec(first=0, last=2, runs=2), report=collect(reports)
+    )
+
+    assert [summary.difficulty for summary in summaries] == [0, 1, 2]
+    assert all(summary.runs == 2 for summary in summaries)
+    # One line per run, and no unreported warmup run inflating the rate
+    assert len(reports) == 6
+    assert reports[0].startswith("difficulty 0 run 1/2:")
+    assert reports[-1].startswith("difficulty 2 run 2/2:")
+
+
+def test_start_benchmark() -> None:
+    reports: list[str] = []
+
+    thread = start_benchmark(
+        BenchmarkSpec(first=0, last=0, runs=1), report=collect(reports)
+    )
+
+    # Backgrounded, so the overlay keeps starting while it runs
+    assert thread.daemon
+    thread.join(timeout=30)
+    assert not thread.is_alive()
+
+    # The run line, then the whole report
+    assert len(reports) == 2
+    assert reports[0].startswith("difficulty 0 run 1/1:")
+    assert "Measured" in reports[1]
+
+
+def test_start_benchmark_reports_its_own_failure() -> None:
+    """A benchmark that breaks must not take the overlay beside it down"""
+    reports: list[str] = []
+
+    def explode(line: str) -> None:
+        if line.startswith("difficulty"):
+            raise RuntimeError("boom")
+        reports.append(line)
+
+    thread = start_benchmark(BenchmarkSpec(first=0, last=0, runs=1), report=explode)
+    thread.join(timeout=30)
+
+    assert not thread.is_alive()
+    assert reports == ["The proof-of-work benchmark failed - see the log for why."]
+
+
+def test_run_benchmark_solves_real_challenges() -> None:
+    """The benchmark measures the shipped solver, not a copy of it"""
+    reports: list[str] = []
+
+    summaries = run_benchmark(
+        BenchmarkSpec(first=6, last=6, runs=1), report=collect(reports)
+    )
+
+    (summary,) = summaries
+    assert summary.mean_hashes >= 1
+    assert summary.hashes_per_second > 0

--- a/tests/prism/overlay/test_commandline.py
+++ b/tests/prism/overlay/test_commandline.py
@@ -2,7 +2,12 @@ import logging
 
 import pytest
 
-from prism.overlay.commandline import Options, get_options, resolve_path
+from prism.overlay.commandline import (
+    DEFAULT_POW_SPEC,
+    Options,
+    get_options,
+    resolve_path,
+)
 
 DEFAULT_SETTINGS = "some_settings_file.toml"
 
@@ -13,6 +18,7 @@ def make_options(
     loglevel: int = logging.INFO,
     test_ssl: bool = False,
     test: bool = False,
+    test_pow: str | None = None,
 ) -> Options:
     """Construct an Options instance from its components"""
     return Options(
@@ -21,6 +27,7 @@ def make_options(
         loglevel=loglevel,
         test_ssl=test_ssl,
         test=test,
+        test_pow=test_pow,
     )
 
 
@@ -44,6 +51,17 @@ test_cases: tuple[tuple[str, Options], ...] = (
     ("--test-ssl", make_options(test_ssl=True)),
     # Test
     ("--test", make_options(test=True)),
+    # Test proof-of-work
+    ("--test-pow", make_options(test_pow=DEFAULT_POW_SPEC)),
+    ("--test-pow 20", make_options(test_pow="20")),
+    ("--test-pow 14-22x3", make_options(test_pow="14-22x3")),
+    # The spec is validated where it is used, not here
+    ("--test-pow nonsense", make_options(test_pow="nonsense")),
+    # An optional argument does not swallow the next flag
+    (
+        "--test-pow --test",
+        make_options(test=True, test_pow=DEFAULT_POW_SPEC),
+    ),
     # Multiple arguments
     (
         "-l somelogfile --settings s.toml",


### PR DESCRIPTION
> [!NOTE]
> **Internal testing only — not intended for production.** This is a calibration tool for picking flashlight's difficulty setting, not a user-facing feature. See *Production exposure* below for what does and does not ship.

Adds `--test-pow`, an internal benchmark for flashlight's proof-of-work difficulty dial. The counterpart to Amund211/rainbow#400, which does the same for the web client.

## What it answers

One question: **at what difficulty does the solve start to cost a user something they would feel?** The report leads with the answer:

```
Starts to hurt at difficulty 21: p95 4.83s (noticeable). Difficulty 20 and under
is free (p95 2.42s). Stops working entirely above 23.
```

## Usage

```
python prism_overlay.py --test -q --test-pow 18-23x5
```

The spec is `FIRST[-LAST][xRUNS]` — `20`, `14-22`, `18x10`, `14-22x3` — and defaults to `16-22x3`. It is parsed before the logfile prompt, so a typo fails immediately rather than after a window is up. `-q` keeps the stats table out of the output.

## Measured

| client | device | rate | starts to hurt | unusable above |
| --- | --- | --- | --- | --- |
| **prism** | desktop | **1,300 kH/s** | **21** | 23 |
| rainbow | desktop browser | 188 kH/s | 18 | 20 |
| rainbow | iPhone 13 mini | 400 kH/s | 19 | 21 |

**prism is the fastest client by a wide margin, so it is not what sets the dial.** The desktop web client starts hurting at difficulty 18, three levels below prism's 21 — anything picked for prism's comfort would already be a noticeable wait on the web. Note also that the *phone* is not the floor here: an iPhone 13 mini is more than twice as fast as the desktop browser.

The ~7x gap between prism and rainbow on the same machine is larger than the underlying SHA-256 work explains; see the rainbow PR for the likely cause.

## Runs beside a live overlay

The benchmark runs on a background daemon thread started just before `run_overlay`, so it measures against a fully started overlay: auth up, stats threads live, tkinter holding the main thread.

That contention is the point. `hashlib` does not release the GIL for inputs this small, so a solve competes with the UI however it is threaded — measuring it in isolation would understate what a user actually feels. A daemon thread, so closing the overlay ends the benchmark with it.

## Fidelity

Everything timed is the shipped code: `solve_challenge` as the auth thread calls it, on a worker thread, at prod's constants, with the challenge minted *outside* the timed region. Deliberately unwarmed, since a login solves exactly one challenge, cold. A benchmark that outruns the real client would report a difficulty as affordable and hand users the sluggishness.

Challenges are minted locally in flashlight's format; nothing is sent to the API. The shape matters for the measurement, not just for looks: each attempt hashes `challenge:solution`, so a real challenge's ~320 characters cost six SHA-256 blocks where a short stand-in would cost one, which would overstate the hash rate several times over.

## Verdict scale

Judged on **p95**, not the mean. Solve time is geometric, so what a user carries away is their worst launches, and an average that looks fine hides them. The scale runs `imperceptible` → `fine` → `noticeable` → `painful`, then the two TTL failures (`unusable - the tail expires`, `does not converge`), and is kept in step with rainbow's page so both clients read on one scale.

The thresholds (1 s / 3 s / 10 s of p95) are judgement calls about perception, not measurements, and are called out as such in the source.

## Production exposure

Worth deciding before this merges, since it is not a user-facing feature:

- `benchmark.py` ships inside the built binary. It is imported only from the `--test-pow` path, so it costs nothing at runtime, but it is present.
- **`--test-pow` currently appears in `--help`**, unlike `--test-ssl` and `--test`, which use `argparse.SUPPRESS`. I made it visible because it takes a spec argument you would otherwise have to remember. Say the word and I will suppress it for consistency with the other test flags.

## Testing

`black`, `isort`, `flake8`, `mypy --strict` and the 100% coverage gate all pass. 66 new tests cover spec parsing, challenge minting and shape, the stats, the verdict ladder (including that it is monotonic and every rung reachable), the headline in all four of its cases, and the threading — that the benchmark is backgrounded, and that a failure inside it reports itself rather than taking the overlay down.

Verified end to end by running the flag against real sweeps; the numbers above are from real runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
