### PR TITLE
chore(deps): pin direct dependencies to exact versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,14 +8,14 @@ authors = [
 ]
 requires-python = ">=3.14"
 dependencies = [
-    "platformdirs",
-    "cachetools",
-    "filelock",
-    "requests>=2.34.2",
-    "toml",
-    "truststore",
-    "pynput",
-    "pywin32; platform_system=='Windows'",
+    "platformdirs==4.11.3",
+    "cachetools==7.1.7",
+    "filelock==3.32.3",
+    "requests==2.34.2",
+    "toml==0.10.2",
+    "truststore==0.10.4",
+    "pynput==1.8.2",
+    "pywin32==312; platform_system=='Windows'",
 ]
 classifiers = [
     "Programming Language :: Python :: 3"
@@ -33,18 +33,18 @@ build-backend = "uv_build"
 
 [dependency-groups]
 dev = [
-    "black>=26.5.1",
-    "coverage>=7.15.2",
-    "flake8>=7.3.0",
-    "isort>=6.0.1",
-    "mypy>=2.3.0",
-    "pillow>=12.3.0",
-    "pre-commit>=4.6.1",
-    "pyinstaller>=6.21.0",
-    "pytest>=9.1.1",
-    "types-pyinstaller>=6.21.0.20260616",
-    "types-pynput>=1.8.1.20260712",
-    "types-toml>=0.10.8.20260518",
+    "black==26.5.1",
+    "coverage==7.15.4",
+    "flake8==7.3.0",
+    "isort==8.0.1",
+    "mypy==2.3.1",
+    "pillow==12.3.0",
+    "pre-commit==4.6.2",
+    "pyinstaller==6.22.2",
+    "pytest==9.1.1",
+    "types-pyinstaller==6.22.0.20260812",
+    "types-pynput==1.8.1.20260712",
+    "types-toml==0.10.8.20260518",
 ]
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -689,30 +689,30 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cachetools" },
-    { name = "filelock" },
-    { name = "platformdirs" },
-    { name = "pynput" },
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
-    { name = "requests", specifier = ">=2.34.2" },
-    { name = "toml" },
-    { name = "truststore" },
+    { name = "cachetools", specifier = "==7.1.7" },
+    { name = "filelock", specifier = "==3.32.3" },
+    { name = "platformdirs", specifier = "==4.11.3" },
+    { name = "pynput", specifier = "==1.8.2" },
+    { name = "pywin32", marker = "sys_platform == 'win32'", specifier = "==312" },
+    { name = "requests", specifier = "==2.34.2" },
+    { name = "toml", specifier = "==0.10.2" },
+    { name = "truststore", specifier = "==0.10.4" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", specifier = ">=26.5.1" },
-    { name = "coverage", specifier = ">=7.15.2" },
-    { name = "flake8", specifier = ">=7.3.0" },
-    { name = "isort", specifier = ">=6.0.1" },
-    { name = "mypy", specifier = ">=2.3.0" },
-    { name = "pillow", specifier = ">=12.3.0" },
-    { name = "pre-commit", specifier = ">=4.6.1" },
-    { name = "pyinstaller", specifier = ">=6.21.0" },
-    { name = "pytest", specifier = ">=9.1.1" },
-    { name = "types-pyinstaller", specifier = ">=6.21.0.20260616" },
-    { name = "types-pynput", specifier = ">=1.8.1.20260712" },
-    { name = "types-toml", specifier = ">=0.10.8.20260518" },
+    { name = "black", specifier = "==26.5.1" },
+    { name = "coverage", specifier = "==7.15.4" },
+    { name = "flake8", specifier = "==7.3.0" },
+    { name = "isort", specifier = "==8.0.1" },
+    { name = "mypy", specifier = "==2.3.1" },
+    { name = "pillow", specifier = "==12.3.0" },
+    { name = "pre-commit", specifier = "==4.6.2" },
+    { name = "pyinstaller", specifier = "==6.22.2" },
+    { name = "pytest", specifier = "==9.1.1" },
+    { name = "types-pyinstaller", specifier = "==6.22.0.20260812" },
+    { name = "types-pynput", specifier = "==1.8.1.20260712" },
+    { name = "types-toml", specifier = "==0.10.8.20260518" },
 ]
 
 [[package]]


### PR DESCRIPTION
Direct deps could only move inside a `chore(deps): lock file maintenance` PR, never as a PR of their own. This pins them so renovate has to ask.

## Why the ranges did not work

Seven of the eight runtime deps carried no version specifier at all (`platformdirs`, `cachetools`, `filelock`, `toml`, `truststore`, `pynput`, `pywin32`). Renovate's pep621 manager marks those [`skipReason: 'unspecified-version'`](https://github.com/renovatebot/renovate/blob/main/lib/modules/manager/pep621/utils.ts) and ignores them — they were invisible to renovate.

The rest carried `>=` floors, and `rangeStrategy: "pin"` would not have fixed those: pep440's [`supportedRangeStrategies`](https://github.com/renovatebot/renovate/blob/main/lib/modules/versioning/pep440/index.ts) is `bump`/`widen`/`replace`, so `pin` logs a warning and falls back to `replace` — and `replace` leaves a floor alone, because every new release already satisfies it.

Either way the only thing that ever moved the dep was `uv lock --upgrade`, which is lock file maintenance.

## What pinning buys

An exact pin is a single version, so `replace` rewrites `==4.11.3` -> `==4.12.0` as a normal PR. Direct bumps arrive one PR at a time, and lock file maintenance is left with the transitive deps — which is what it is for.

This is renovate's own advice for applications ([dependency pinning](https://docs.renovatebot.com/dependency-pinning/)). prism is not published to PyPI, so no consumer inherits these pins.

`[dependency-groups]` is pinned for the same reason. Note that `:pinDevDependencies` cannot reach it: that preset matches depTypes `devDependencies`/`dev-dependencies`/`dev`, and PEP 735 groups are depType `dependency-groups`.

## Risk

None at install time. Every pin is the version `uv.lock` had already resolved, so no resolved version changes — the `uv.lock` diff is `requires-dist` metadata only. `uv lock --check` passes.
