### PR TITLE
chore: group non-major updates into one PR

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,6 +32,13 @@
   automerge: false,
   packageRules: [
     {
+      // Batch routine updates into one PR. Must stay first — later rules win,
+      // so the group rules below keep their own groupName. Majors stay
+      // separate; separateMajorMinor splits them out regardless of grouping.
+      matchUpdateTypes: ["minor", "patch", "digest"],
+      groupName: "all non-major dependencies",
+    },
+    {
       // A digest-only move on a SHA-pinned action means an existing tag was
       // repointed upstream — the tag-hijack signature (tj-actions/changed-files,
       // CVE-2025-30066). Legitimate fixes arrive as a new tag through the normal


### PR DESCRIPTION
Batches minor, patch and digest updates under one `all non-major dependencies` group, so routine churn arrives as a single PR per schedule window instead of one PR per dependency.

## What is left out, and why

| updateType | In the group? | Why |
| --- | --- | --- |
| `minor`, `patch` | yes | The churn. Note both are needed: with the default `separateMinorPatch: false` a dep offering both gets one update labelled `minor`, but a dep offering only a patch is labelled `patch`. |
| `digest` | yes | Otherwise every docker digest move is its own PR — `digest` is the one updateType with no default `groupName`. |
| `major` | no | Wants a real read, one at a time. |
| `pin` | no | Renovate already groups these: the `pin` default config sets `groupName: "Pin Dependencies"`. |
| `lockFileMaintenance` | no | Its own PR by design. |

## Does this interfere with renovate's built-in groupings?

Yes, deliberately, in one direction — and the answer is worth writing down.

`config:recommended` (via `config:best-practices`) extends `group:monorepos` and `group:recommended`, which add a `groupName` per monorepo — tanstack-router, vitest, mui, opentelemetry-go and so on. Those arrive from `extends`, so they land in `packageRules` **before** anything written in this file. Later rules win field-by-field, so for minor/patch/digest this rule overwrites their `groupName` and they all collapse into the one group. The monorepo presets keep applying to `major`.

That is not a loss of lockstep. It is the opposite: monorepo members that used to land as one PR per monorepo now land in the same single PR, so they still move together.

Two things the ordering does protect:

- The rule is **first** in `packageRules`, so every group rule after it — `go version` in flashlight, `playwright` in rainbow — re-sets `groupName` for what it matches and keeps its own PR.
- `enabled: false` rules after it (the github-actions digest block) still win, so those stay disabled.

## Cost

A grouped PR is all-or-nothing: one dep that breaks CI holds up everything else in the PR. Grouping is also not atomic — renovate drops any member that has not cleared `minimumReleaseAge` and regenerates the branch as members age in, so the PR can churn during the week.

## Verified

`renovate-config-validator` passes.
